### PR TITLE
fix(nuget-push): remove trailing slash on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 > All notable changes to this project will be documented in this file.
 
+<a name="2.0.1-alpha-02811"></a>
+## 2.0.1-alpha-02811 (2017-04-15)
+
+
+### Bug Fixes
+
+* **slashes:** normalize slashes everywhere b86d317
+
+
 <a name="2.0.1-alpha-02810"></a>
 ## 2.0.1-alpha-02810 (2017-04-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,14 @@
 
 > All notable changes to this project will be documented in this file.
 
-<a name="2.0.1-alpha-02797"></a>
-## 2.0.1-alpha-02797 (2017-04-12)
-
-
-<a name="2.0.1-alpha-02796"></a>
-## 2.0.1-alpha-02796 (2017-04-12)
-
-
-<a name="2.0.1-alpha-02794"></a>
-## 2.0.1-alpha-02794 (2017-04-12)
+<a name="2.0.1-alpha-02810"></a>
+## 2.0.1-alpha-02810 (2017-04-15)
 
 
 ### Bug Fixes
 
-* **semver:** ensure master branch always uses next version 14b3d65
+* **nuget-push:** remove trailing slash on windows 302d5fa
+* ensure master branch always uses next version (#63) 0777c6b, closes #63
 
 
 <a name="2.0.0-beta-02716"></a>

--- a/src/AM.Condo/Targets/Compile.targets
+++ b/src/AM.Condo/Targets/Compile.targets
@@ -28,14 +28,14 @@
 
   <Target Name="CopyDotNetBuild">
     <ItemGroup>
-      <_CopyDotNetBuild Include="%(DotNetProjects.ProjectDir)bin$(Slash)**" Exclude="%(DotNetProjects.ProjectDir)bin$(slash)publish$(slash)**">
+      <_CopyDotNetBuild Include="%(DotNetProjects.ProjectDir)bin$(slash)**" Exclude="%(DotNetProjects.ProjectDir)bin$(slash)publish$(slash)**">
         <ProjectName>%(DotNetProjects.ProjectName)</ProjectName>
       </_CopyDotNetBuild>
     </ItemGroup>
 
     <Copy
         SourceFiles="@(_CopyDotNetBuild)"
-        DestinationFiles="@(_CopyDotNetBuild->'$(BuildArtifactsRoot)$(Slash)%(ProjectName)$(Slash)%(RecursiveDir)%(Filename)%(Extension)')" />
+        DestinationFiles="@(_CopyDotNetBuild->'$(BuildArtifactsRoot)$(slash)%(ProjectName)$(slash)%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 
   <PropertyGroup>

--- a/src/AM.Condo/Targets/Initialize.targets
+++ b/src/AM.Condo/Targets/Initialize.targets
@@ -32,12 +32,8 @@
     <PublishArtifactsRoot   Condition=" '$(PublishArtifactsRoot)'   == '' ">$(ArtifactsRoot)publish$(slash)</PublishArtifactsRoot>
     <PublishArtifactsRoot   Condition=" !HasTrailingSlash('$(PublishArtifactsRoot)') ">$(PublishArtifactsRoot)$(slash)</PublishArtifactsRoot>
 
-    <PackageArtifactsRoot   Condition=" '$(PackageArtifactsRoot)'   == '' ">$(ArtifactsRoot)packages</PackageArtifactsRoot>
-
-    <!-- does dotnet pack have issues with trailing slashes on windows?
     <PackageArtifactsRoot   Condition=" '$(PackageArtifactsRoot)'   == '' ">$(ArtifactsRoot)packages$(slash)</PackageArtifactsRoot>
     <PackageArtifactsRoot   Condition=" !HasTrailingSlash('$(PackageArtifactsRoot)') ">$(PackageArtifactsRoot)$(slash)</PackageArtifactsRoot>
-    -->
 
     <FeedArtifactsRoot      Condition=" '$(FeedArtifactsRoot)'      == '' ">$(ArtifactsRoot)feed$(slash)</FeedArtifactsRoot>
     <FeedArtifactsRoot      Condition=" !HasTrailingSlash('$(FeedArtifactsRoot)') ">$(FeedArtifactsRoot)feed$(slash)</FeedArtifactsRoot>

--- a/src/AM.Condo/Targets/Package.targets
+++ b/src/AM.Condo/Targets/Package.targets
@@ -21,8 +21,8 @@
         WorkingDirectory="$(RepositoryRoot)" />
 
     <ItemGroup>
-      <AllPackages Include="$(PackageArtifactsRoot)$(slash)*.nupkg" />
-      <Symbols Include="$(PackageArtifactsRoot)$(slash)*.symbols.nupkg" />
+      <AllPackages Include="$(PackageArtifactsRoot)*.nupkg" />
+      <Symbols Include="$(PackageArtifactsRoot)*.symbols.nupkg" />
       <Packages Include="@(AllPackages)" Exclude="@(Symbols)" />
     </ItemGroup>
   </Target>

--- a/src/AM.Condo/Targets/Package.targets
+++ b/src/AM.Condo/Targets/Package.targets
@@ -4,7 +4,7 @@
   <Target Name="DotNetPack" Condition=" '$(DotNetPack)' != 'skip' ">
     <PropertyGroup>
       <DotNetPackOptions Condition=" '$(DotNetPackOptions)' == '' ">$(DOTNET_PACK_OPTIONS)</DotNetPackOptions>
-      <DotNetPackOptions>$(DotNetPackOptions) --output &quot;$(PackageArtifactsRoot)&quot;</DotNetPackOptions>
+      <DotNetPackOptions>$(DotNetPackOptions) --output &quot;$(PackageArtifactsRoot.TrimEnd('$(slash)'))&quot;</DotNetPackOptions>
       <DotNetPackOptions>$(DotNetPackOptions) --no-build</DotNetPackOptions>
       <DotNetPackOptions Condition=" '$(Configuration)' != '' ">$(DotNetPackOptions) --configuration &quot;$(Configuration)&quot;</DotNetPackOptions>
 

--- a/src/AM.Condo/Targets/Publish.targets
+++ b/src/AM.Condo/Targets/Publish.targets
@@ -18,7 +18,7 @@
 
     <ItemGroup>
       <_DotNetPublish Include="@(DotNetPublishProjects)">
-        <OutputPath>&quot;$(PublishArtifactsRoot)$(Slash)%(ProjectName)&quot;</OutputPath>
+        <OutputPath>&quot;$(PublishArtifactsRoot)%(ProjectName)&quot;</OutputPath>
         <WorkingDirectory>%(RootDir)%(Directory)</WorkingDirectory>
         <PublishName>&quot;%(Filename)%(Extension)&quot;</PublishName>
       </_DotNetPublish>

--- a/src/AM.Condo/Targets/Publish.targets
+++ b/src/AM.Condo/Targets/Publish.targets
@@ -31,20 +31,16 @@
   </Target>
 
   <Target Name="InstallPackages" Condition=" '@(Packages->Count())' != '0' ">
-    <Exec Command="dotnet nuget push &quot;%(Packages.Identity)&quot; --source &quot;$(FeedArtifactsRoot)&quot;" />
+    <PropertyGroup>
+      <DotNetLocalPushOptions Condition=" '$(DotNetPushLocalOptions)' == '' ">$(DOTNET_LOCAL_PUSH_OPTIONS)</DotNetLocalPushOptions>
+      <DotNetLocalPushOptions>$(DotNetLocalPushOptions.Trim()) --source &quot;$(FeedArtifactsRoot.TrimEnd('$(slash)'))&quot;</DotNetLocalPushOptions>
+      <DotNetLocalPushOptions>$(DotNetLocalPushOptions.Trim())</DotNetLocalPushOptions>
+    </PropertyGroup>
+
+    <Exec Command="dotnet nuget push &quot;%(Packages.Identity)&quot; $(DotNetLocalPushOptions)" />
   </Target>
 
   <Target Name="PublishPackages" Condition=" $(CI) AND '$(PackageFeedUri)' != '' AND '@(Packages->Count())' != '0' ">
-    <PropertyGroup>
-      <NuGetPushOptions Condition=" '$(NuGetPushOptions)' == '' ">$(NUGET_PUSH_OPTIONS)</NuGetPushOptions>
-      <NuGetPushOptions Condition=" '$(PackageFeedUri)' != '' ">$(NuGetPushOptions) --source $(PackageFeedUri)</NuGetPushOptions>
-      <NuGetPushOptions Condition=" '$(PackageFeedApiKey)' != '' ">$(NuGetPushOptions) --api-key $(PackageFeedApiKey)</NuGetPushOptions>
-      <NuGetPushOptions Condition=" '$(PackageSymbolUri)' != '' ">$(NuGetPushOptions) --symbol-source $(PackageSymbolUri)</NuGetPushOptions>
-      <NuGetPushOptions Condition=" '$(PackageSymbolApiKey)' != '' ">$(NuGetPushOptions) --symbol-api-key $(PackageSymbolApiKey)</NuGetPushOptions>
-      <NuGetPushOptions Condition="$(PackageNoSymbols)">$(NuGetPushOptions) --no-symbols</NuGetPushOptions>
-      <NuGetPushOptions Condition=" '$(NuGetConfigPath)' != '' ">$(NuGetPushOptions) --config-file $(NuGetConfigPath)</NuGetPushOptions>
-    </PropertyGroup>
-
     <PushNuGetPackage
       NuGetConfigPath="$(NuGetConfigPath)"
       Packages="@(Packages)"
@@ -53,8 +49,6 @@
       SymbolUri="$(PackageSymbolUri)"
       SymbolApiKey="$(PackageSymbolApiKey)"
       NoSymbols="$(PackageNoSymbols)" />
-
-    <!--<Exec Command="dotnet nuget push &quot;%(Packages.Identity)&quot; $(NuGetPushOptions)" />-->
   </Target>
 
   <PropertyGroup>


### PR DESCRIPTION
* remove the trailing slash on nuget operations to resolve an issue where `dotnet-nuget push` and `dotnet-nuget pack` commands can fail on windows with `Illegal characters in path` errors