### PR TITLE
fix(publish): improve publish target detection

### DIFF
--- a/src/AM.Condo.Xunit/AM.Condo.Xunit.csproj
+++ b/src/AM.Condo.Xunit/AM.Condo.Xunit.csproj
@@ -7,6 +7,7 @@
     <CodeAnalysisRuleSet>../../stylecop.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Pack>false</Pack>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AM.Condo/Targets/Package.targets
+++ b/src/AM.Condo/Targets/Package.targets
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <DotNetPackProjects Include="@(SourceProjects)" Condition=" '@(DotNetPackProjects->Count())' == '0' " />
+      <DotNetPackProjects Include="@(SourceProjects)" Condition=" '@(DotNetPackProjects->Count())' == '0' AND %(SourceProjects.Pack) " />
     </ItemGroup>
 
     <Exec


### PR DESCRIPTION
* set default output-type to library if not otherwise available
* execute publish target for output-type != library
* execute pack target for output-type == library
* allow user-override via `<Publish>true|false</Publish>`
* allow user-override via `<Pack>true|false</Pack>`

Closes: #66 