### PR TITLE
fix(restore): ignore failed sources on initial restore

### DIFF
--- a/src/AM.Condo/Scripts/condo.ps1
+++ b/src/AM.Condo/Scripts/condo.ps1
@@ -185,7 +185,7 @@ function Install-Condo() {
 
     # restore msbuild
     Write-Info "condo: restoring condo packages..."
-    Invoke-Cmd dotnet restore $SrcRoot --runtime $runtime --verbosity minimal
+    Invoke-Cmd dotnet restore $SrcRoot --runtime $runtime --verbosity minimal --ignore-failed-sources
     Write-Success "condo: restore complete"
 
     # publish condo

--- a/src/AM.Condo/Scripts/condo.sh
+++ b/src/AM.Condo/Scripts/condo.sh
@@ -124,7 +124,7 @@ install_condo() {
 
         # restore condo
         info "condo: restoring condo packages..."
-        safe-exec dotnet restore $SRC_ROOT --runtime $RUNTIME --verbosity minimal
+        safe-exec dotnet restore $SRC_ROOT --runtime $RUNTIME --verbosity minimal --ignore-failed-sources
         success "condo: restore complete"
 
         # publish condo

--- a/src/AM.Condo/Targets/Prepare.targets
+++ b/src/AM.Condo/Targets/Prepare.targets
@@ -10,7 +10,7 @@
   <Target Name="DotNetRestore" Condition=" '$(DotNetRestore)' != 'skip' AND '@(DotNetRestorePaths->Count())' != '0' ">
     <PropertyGroup>
       <DotNetRestoreOptions Condition=" '$(DotNetRestoreOptions)' == '' ">$(DOTNET_RESTORE_OPTIONS)</DotNetRestoreOptions>
-      <DotNetRestoreOptions Condition=" '$(NuGetConfigPath)' != '' ">$(DotNetRestoreOptions) --configfile &quot;$(NuGetConfigPath)&quot;</DotNetRestoreOptions>
+      <DotNetRestoreOptions Condition=" '$(NuGetConfigPath)' != '' ">$(DotNetRestoreOptions) --ignore-failed-sources --configfile &quot;$(NuGetConfigPath)&quot;</DotNetRestoreOptions>
 
       <DotNetRestoreProperties Condition=" '$(InformationalVersion)' != '' ">$(DotNetRestoreProperties) /p:Version=$(InformationalVersion)</DotNetRestoreProperties>
 

--- a/src/AM.Condo/Targets/Prepare.targets
+++ b/src/AM.Condo/Targets/Prepare.targets
@@ -10,7 +10,8 @@
   <Target Name="DotNetRestore" Condition=" '$(DotNetRestore)' != 'skip' AND '@(DotNetRestorePaths->Count())' != '0' ">
     <PropertyGroup>
       <DotNetRestoreOptions Condition=" '$(DotNetRestoreOptions)' == '' ">$(DOTNET_RESTORE_OPTIONS)</DotNetRestoreOptions>
-      <DotNetRestoreOptions Condition=" '$(NuGetConfigPath)' != '' ">$(DotNetRestoreOptions) --ignore-failed-sources --configfile &quot;$(NuGetConfigPath)&quot;</DotNetRestoreOptions>
+      <DotNetRestoreOptions>$(DotNetRestoreOptions.Trim()) --ignore-failed-sources</DotNetRestoreOptions>
+      <DotNetRestoreOptions Condition=" '$(NuGetConfigPath)' != '' ">$(DotNetRestoreOptions.Trim()) --configfile &quot;$(NuGetConfigPath)&quot;</DotNetRestoreOptions>
 
       <DotNetRestoreProperties Condition=" '$(InformationalVersion)' != '' ">$(DotNetRestoreProperties) /p:Version=$(InformationalVersion)</DotNetRestoreProperties>
 


### PR DESCRIPTION
When condo executes `dotnet restore` during both the installation of itself, and also during the restore target of the lifecycle when building a project, it will now ignore failing feeds, including those that are configured at the user level with encrypted credentials.

Previously, condo would fail to install and the build of a project would fail if encrypted nuget credentials existed in the user-level nuget.config on Windows. dotnet core does not support the Windows Data Protection API (DPAPI) as it is not cross-platform, which is the underlying cause of this error.