### PR TITLE
chore: set the sdk version of dotnet

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json.schemastore.org/global",
+  "sdk": {
+    "version": "1.0.1"
+  }
+}


### PR DESCRIPTION
* use `global.json` to set the SDK version of dotnet so `dotnet-cli` commands don't use the 2.0.0-preview SDK if they are installed