### PR TITLE
bugfix(git-log): add support for VSTS merge commits

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json.schemastore.org/global",
+  "sdk": {
+    "version": "1.0.1"
+  }
+}

--- a/src/AM.Condo.IO/GitRepository.cs
+++ b/src/AM.Condo.IO/GitRepository.cs
@@ -330,7 +330,7 @@ namespace AM.Condo.IO
                 range += to;
             }
 
-            var cmd = $@"log --tags {range} --format=""{Format}""";
+            var cmd = $@"log {range} --format=""{Format}""";
 
             // create the command used to get the history of commits
             var exec = this.Execute(cmd);

--- a/src/AM.Condo/Targets/Versioning/Angular/presets.targets
+++ b/src/AM.Condo/Targets/Versioning/Angular/presets.targets
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <FieldPattern           Condition=" '$(FieldPattern)'           == '' ">^-(.*?)-$</FieldPattern>
 
-    <HeaderPattern          Condition=" '$(HeaderPattern)'          == '' ">^(\w*)(?:\(([\w\$\.\-\* ]*)\))?\: (.*)$</HeaderPattern>
-    <HeaderCorrespondence   Condition=" '$(HeaderCorrespondence)'   == '' ">Type;Scope;Subject</HeaderCorrespondence>
+    <HeaderPattern          Condition=" '$(HeaderPattern)'          == '' ">^(?:[Mm]erged (\w*) (\d*): )?(\w*)(?:\(([\w\$\.\-\* ]*)\))?\: (.*)$</HeaderPattern>
+    <HeaderCorrespondence   Condition=" '$(HeaderCorrespondence)'   == '' ">MergeType;MergeReference;Type;Scope;Subject</HeaderCorrespondence>
 
     <RevertPattern          Condition=" '$(RevertPattern)'          == '' ">^Revert\s""([\s\S]*)""\s*This reverts commit (\w*)\.</RevertPattern>
     <RevertCorrespondence   Condition=" '$(RevertCorrespondence)'   == '' ">RevertHeader;RevertHash</RevertCorrespondence>

--- a/src/AM.Condo/Targets/Versioning/Conventional.targets
+++ b/src/AM.Condo/Targets/Versioning/Conventional.targets
@@ -5,6 +5,8 @@
     <ChangeLogInitialize Condition=" '$(ChangeLogInitialize)' == '' ">$(MSBuildThisFileDirectory)$(slash)changelog.md</ChangeLogInitialize>
     <AllowPushCommits Condition=" '$(AllowPushCommits)' == '' ">$(CONDO_PUSH_COMMITS)</AllowPushCommits>
     <AllowPushCommits Condition=" '$(AllowPushCommits)' == '' ">True</AllowPushCommits>
+    <PrintIncludedCommits Condition=" '$(PrintIncludedCommits)' == '' ">$(CONDO_PRINT_COMMITS)</PrintIncludedCommits>
+    <PrintIncludedCommits Condition=" '$(PrintIncludedCommits)' == '' ">False</PrintIncludedCommits>
   </PropertyGroup>
 
   <!-- detect convention strategy -->
@@ -36,7 +38,13 @@
       VersionTagPrefix="$(VersionTagPrefix)">
       <Output TaskParameter="From" PropertyName="CommitFrom" />
       <Output TaskParameter="To" PropertyName="CommitTo" />
+      <Output TaskParameter="Commits" ItemName="IncludedCommits" />
     </GetCommitInfo>
+  </Target>
+
+  <!-- print the commits if requested -->
+  <Target Name="PrintCommits" Condition="$(PrintIncludedCommits) AND '@(IncludedCommits->Count())' != '0' ">
+    <Message Importance="High" Text="(%(IncludedCommits.ShortHash)) %(IncludedCommits.Header)" />
   </Target>
 
   <!-- update semantic version -->
@@ -100,6 +108,7 @@
     <BeforeVersion>
       $(BeforeVersion);
       GetCommitInfo;
+      PrintCommits;
       RecommendVersion;
       CheckoutReleaseBranch;
     </BeforeVersion>

--- a/src/AM.Condo/Tasks/GetCommitInfo.cs
+++ b/src/AM.Condo/Tasks/GetCommitInfo.cs
@@ -150,56 +150,60 @@ namespace AM.Condo.Tasks
         /// Will contain a list of all commits that comply with the indicated format.
         /// The SHA value will be the <see cref="ITaskItem.ItemSpec"/>. In addition, the task items will contain
         /// metadata that describes any commit that follows the conventional-changelog style guide. This metadata
-        /// includes the following:
+        /// includes (at least) the following:
         /// <list type="bullet">
         /// <item>
-        ///     <term>Type</term>
+        ///     <term>Hash</term>
         ///     <description>
-        ///     The type (of change) for the commit, which may be Features, Performance Improvements, Bug Fixes,
-        ///     Documentation, Styles, Code Refactoring, Tests or Chores.
+        ///     The full SHA for the commit.
         ///     </description>
         /// </item>
         /// <item>
-        ///     <term>Scope</term>
+        ///     <term>ShortHash</term>
         ///     <description>
-        ///     The component in which the change occurred.
+        ///     The first 7 (or more required for uniqueness) characters of the SHA for the commit.
         ///     </description>
         /// </item>
         /// <item>
-        ///     <term>Subject</term>
+        ///     <term>Header</term>
         ///     <description>
-        ///     The subject, or description, of the change that occurred.
+        ///     The first line of the commit message.
         ///     </description>
         /// </item>
         /// <item>
         ///     <term>Body</term>
         ///     <description>
-        ///     The body that describes additional details about the change that occurred.
+        ///     The remaining lines of the commit message.
         ///     </description>
         /// </item>
         /// <item>
-        ///     <term>Closes</term>
+        ///     <term>Raw</term>
         ///     <description>
-        ///     A semi-colon (;) delimited list of issues (work items) that are closed (resolved) by the commit.
+        ///     The raw payload of the commit message.
+        ///     </description>
+        /// </item>
+        /// <item>
+        ///     <term>Branches</term>
+        ///     <description>
+        ///     A semi-colon delimited list of branches associated with the commit.
+        ///     </description>
+        /// </item>
+        /// <item>
+        ///     <term>Tags</term>
+        ///     <description>
+        ///     A semi-colon delimited list of tags associated with the commit.
         ///     </description>
         /// </item>
         /// <item>
         ///     <term>References</term>
         ///     <description>
-        ///     A semi-colon (;) delimited list of references (work items) that are related to the commit.
+        ///     A semi-colon delimited list of work item ids associated with the commit.
         ///     </description>
         /// </item>
         /// <item>
-        ///     <term>Breaking</term>
+        ///     <term>Notes</term>
         ///     <description>
-        ///     A summary description of breaking changes associated with the commit.
-        ///     </description>
-        /// </item>
-        /// <item>
-        ///     <term>Message</term>
-        ///     <description>
-        ///     The entire commit message including new-lines. This is useful for commits that do not follow the
-        ///     conventional changelog style.
+        ///     The total number of notes or breaking changes associated with the commit.
         ///     </description>
         /// </item>
         /// </list>


### PR DESCRIPTION
* feat(git-log): add support for VSTS merge commits

Add support for the *ugly* `Merged PR <NUMBER>: ` prefix that VSTS likes to add to commit messages. In the future, we will include the PR reference in the changelog when it is available.

* bugfix(git-log): remove --tags from git log

When `--tags` was used to include tags in the git log, some commits where not included. We believe this is a bug in either git itself, or the git-scm documentation. In the meantime, we no longer require this since tags are included in the format.

Closes: #77, #78