### PR TITLE
perf(dotnet): opt out of dotnet cli telemetry

### DIFF
--- a/src/AM.Condo/Scripts/condo.ps1
+++ b/src/AM.Condo/Scripts/condo.ps1
@@ -62,6 +62,9 @@ function Get-File([string] $url, [string] $path, [int] $retries = 5) {
     }
 }
 
+# disable dotnet cli telemetry to speed up the build
+$env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
+
 # set well-known paths
 $WorkingPath = Convert-Path (Get-Location)
 

--- a/src/AM.Condo/Scripts/condo.sh
+++ b/src/AM.Condo/Scripts/condo.sh
@@ -25,6 +25,9 @@ CONDO_TARGETS="$CONDO_PUBLISH/Targets"
 CONDO_PROJ="$WORKING_PATH/condo.build"
 CONDO_VERBOSITY="normal"
 
+# disable dotnet cli telemetry to speed up the build
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+
 success() {
     echo -e "${CLR_SUCCESS}$@${CLR_CLEAR}"
     echo "log  : $@" >> $CONDO_LOG


### PR DESCRIPTION
Improve the speed of the build by opting out of sending data to MS on dotnet CLI commands