### PR TITLE
perf(dotnet): disable xml generation on nuget restore

### DIFF
--- a/src/AM.Condo/Scripts/condo.ps1
+++ b/src/AM.Condo/Scripts/condo.ps1
@@ -65,6 +65,9 @@ function Get-File([string] $url, [string] $path, [int] $retries = 5) {
 # disable dotnet cli telemetry to speed up the build
 $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
 
+# disable xml creation on nuget restore to speed up the build
+$env:NUGET_XMLDOC_MODE = "skip"
+
 # set well-known paths
 $WorkingPath = Convert-Path (Get-Location)
 

--- a/src/AM.Condo/Scripts/condo.sh
+++ b/src/AM.Condo/Scripts/condo.sh
@@ -28,6 +28,9 @@ CONDO_VERBOSITY="normal"
 # disable dotnet cli telemetry to speed up the build
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 
+# disable xml creation on nuget restore to speed up the build
+export NUGET_XMLDOC_MODE="skip"
+
 success() {
     echo -e "${CLR_SUCCESS}$@${CLR_CLEAR}"
     echo "log  : $@" >> $CONDO_LOG


### PR DESCRIPTION
* speed up our builds by not generating xml files in the artifacts/publish directory on nuget restore