### PR TITLE
bugfix(docs): add default github pages value

### DIFF
--- a/src/AM.Condo/Targets/Document.targets
+++ b/src/AM.Condo/Targets/Document.targets
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="DocFXPlatformWarning" Condition=" '$(DocFXDocs)' != 'skip' AND '@(DocFXProjects->Count())' != '0' AND !$(IsWindows) ">
-    <Warning Text="DocFX is only supported on Windows, currently. Mono is no longer supported as of version 2.6." />
-  </Target>
-
   <PropertyGroup>
     <DocsGenerated>false</DocsGenerated>
+    <GitHubPages Condition=" '$(GitHubPages)' == '' ">false</GitHubPages>
   </PropertyGroup>
+
+<Target Name="DocFXPlatformWarning" Condition=" '$(DocFXDocs)' != 'skip' AND '@(DocFXProjects->Count())' != '0' AND !$(IsWindows) ">
+    <Warning Text="DocFX is only supported on Windows, currently. Mono is no longer supported as of version 2.6." />
+  </Target>
 
   <Target Name="DocFXDocs" Condition=" '$(DocFXDocs)' != 'skip' AND '@(DocFXProjects->Count())' != '0' AND $(IsWindows) ">
     <PropertyGroup>


### PR DESCRIPTION
add a default value for the `GitHubPages` property used to determine whether or not generated documentation should be published to GitHub Pages. In the past, no default value exists, which would cause an error if the `AfterPublish` target called the `PublishGitHubPages` target whereby the `GitHubPages` property could not be evaluated as a Boolean since it was empty.

Resolves: #98 