### PR TITLE
feat(versioning): add envars for release versions

### DIFF
--- a/src/AM.Condo/AM.Condo.tasks
+++ b/src/AM.Condo/AM.Condo.tasks
@@ -24,6 +24,7 @@
   <UsingTask AssemblyFile="AM.Condo.dll" TaskName="AM.Condo.Tasks.RestoreSubmodules" />
   <UsingTask AssemblyFile="AM.Condo.dll" TaskName="AM.Condo.Tasks.SaveAssemblyInfo" />
   <UsingTask AssemblyFile="AM.Condo.dll" TaskName="AM.Condo.Tasks.SaveChangeLog" />
+  <UsingTask AssemblyFile="AM.Condo.dll" TaskName="AM.Condo.Tasks.SaveFile" />
   <UsingTask AssemblyFile="AM.Condo.dll" TaskName="AM.Condo.Tasks.SetGitTag" />
   <UsingTask AssemblyFile="AM.Condo.dll" TaskName="AM.Condo.Tasks.SetNuGetPackageSources" />
   <UsingTask AssemblyFile="AM.Condo.dll" TaskName="AM.Condo.Tasks.SetEnvironmentVariable" />

--- a/src/AM.Condo/AM.Condo.tasks
+++ b/src/AM.Condo/AM.Condo.tasks
@@ -26,6 +26,7 @@
   <UsingTask AssemblyFile="AM.Condo.dll" TaskName="AM.Condo.Tasks.SaveChangeLog" />
   <UsingTask AssemblyFile="AM.Condo.dll" TaskName="AM.Condo.Tasks.SetGitTag" />
   <UsingTask AssemblyFile="AM.Condo.dll" TaskName="AM.Condo.Tasks.SetNuGetPackageSources" />
+  <UsingTask AssemblyFile="AM.Condo.dll" TaskName="AM.Condo.Tasks.SetEnvironmentVariable" />
   <UsingTask AssemblyFile="AM.Condo.dll" TaskName="AM.Condo.Tasks.WaitForDebugger" />
   <UsingTask AssemblyFile="AM.Condo.dll" TaskName="AM.Condo.Tasks.WaitForFile" />
 </Project>

--- a/src/AM.Condo/Tasks/GetBuildQuality.cs
+++ b/src/AM.Condo/Tasks/GetBuildQuality.cs
@@ -7,6 +7,7 @@
 namespace AM.Condo.Tasks
 {
     using System;
+    using System.Security;
 
     using Microsoft.Build.Framework;
     using Microsoft.Build.Utilities;
@@ -126,7 +127,7 @@ namespace AM.Condo.Tasks
         public override bool Execute()
         {
             // set the prelrease tag to alpha by default
-            this.BuildQuality = this.DefaultBuildQuality;
+            this.SetBuildQuality(this.DefaultBuildQuality);
 
             // only inspect the current branch when running on a build server
             if (!this.CI)
@@ -138,7 +139,7 @@ namespace AM.Condo.Tasks
             if (this.Branch.Equals(this.ProductionReleaseBranch, StringComparison.OrdinalIgnoreCase))
             {
                 // set the build quality to the master branch build quality
-                this.BuildQuality = this.ProductionReleaseBranchBuildQuality;
+                this.SetBuildQuality(this.ProductionReleaseBranchBuildQuality);
 
                 // set the create release flag
                 this.CreateRelease = true;
@@ -152,7 +153,7 @@ namespace AM.Condo.Tasks
                 && this.Branch.Equals(this.NextReleaseBranch, StringComparison.OrdinalIgnoreCase))
             {
                 // set the build quality to the develop branch build quality
-                this.BuildQuality = this.NextReleaseBranchBuildQuality;
+                this.SetBuildQuality(this.NextReleaseBranchBuildQuality);
 
                 // move on immediately
                 return true;
@@ -163,7 +164,7 @@ namespace AM.Condo.Tasks
                 && this.Branch.StartsWith(this.FeatureBranchPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 // set the build quality to the feature branch build quality
-                this.BuildQuality = this.FeatureBranchBuildQuality;
+                this.SetBuildQuality(this.FeatureBranchBuildQuality);
 
                 // move on immediately
                 return true;
@@ -174,7 +175,7 @@ namespace AM.Condo.Tasks
                 && this.Branch.StartsWith(this.BugfixBranchPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 // set the build quality to the bugfix branch build quality
-                this.BuildQuality = this.BugfixBranchBuildQuality;
+                this.SetBuildQuality(this.BugfixBranchBuildQuality);
 
                 // move on immediately
                 return true;
@@ -185,7 +186,7 @@ namespace AM.Condo.Tasks
                 && this.Branch.StartsWith(this.ReleaseBranchPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 // set the build quality to the release branch build quality
-                this.BuildQuality = this.ReleaseBranchBuildQuality;
+                this.SetBuildQuality(this.ReleaseBranchBuildQuality);
 
                 // set the create release flag
                 this.CreateRelease = true;
@@ -199,7 +200,7 @@ namespace AM.Condo.Tasks
                 && this.Branch.StartsWith(this.SupportBranchPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 // set the build quality to the support branch build quality
-                this.BuildQuality = this.SupportBranchBuildQuality;
+                this.SetBuildQuality(this.SupportBranchBuildQuality);
 
                 // set the create release flag
                 this.CreateRelease = true;
@@ -213,7 +214,7 @@ namespace AM.Condo.Tasks
                 && this.Branch.StartsWith(this.HotfixBranchPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 // set the build quality to the hotfix branch build quality
-                this.BuildQuality = this.HotfixBranchBuildQuality;
+                this.SetBuildQuality(this.HotfixBranchBuildQuality);
 
                 // set the create release flag
                 this.CreateRelease = true;
@@ -224,6 +225,20 @@ namespace AM.Condo.Tasks
 
             // assume there is nothing to do
             return true;
+        }
+
+        private void SetBuildQuality(string quality)
+        {
+            this.BuildQuality = quality;
+
+            try
+            {
+                Environment.SetEnvironmentVariable(nameof(this.BuildQuality), this.BuildQuality);
+            }
+            catch (SecurityException securityEx)
+            {
+                this.Log.LogWarningFromException(securityEx);
+            }
         }
         #endregion
     }

--- a/src/AM.Condo/Tasks/RecommendVersion.cs
+++ b/src/AM.Condo/Tasks/RecommendVersion.cs
@@ -8,6 +8,7 @@ namespace AM.Condo.Tasks
 {
     using System;
     using System.Linq;
+    using System.Security;
 
     using AM.Condo.IO;
 
@@ -109,6 +110,10 @@ namespace AM.Condo.Tasks
             this.CurrentVersion = version.ToNormalizedString();
             this.CurrentRelease = version.ToString("V", VersionFormatter.Instance);
 
+            // set the current version and release variables
+            this.SetReleaseEnvironmentVariable(nameof(this.CurrentVersion), this.CurrentVersion);
+            this.SetReleaseEnvironmentVariable(nameof(this.CurrentRelease), this.CurrentRelease);
+
             // get the level for the next version
             var level = this.RecommendLevel(lastCommit);
 
@@ -117,6 +122,10 @@ namespace AM.Condo.Tasks
 
             // set the recommended version
             this.RecommendedRelease = RecommendRelease(version, level, this.BuildQuality);
+
+            // set the next release and recommended release variables
+            this.SetReleaseEnvironmentVariable(nameof(this.NextRelease), this.NextRelease);
+            this.SetReleaseEnvironmentVariable(nameof(this.RecommendedRelease), this.RecommendedRelease);
 
             // move on immediately
             return true;
@@ -205,6 +214,18 @@ namespace AM.Condo.Tasks
 
             // return the level
             return level;
+        }
+
+        private void SetReleaseEnvironmentVariable(string name, string value)
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable(name, value);
+            }
+            catch (SecurityException securityEx)
+            {
+                this.Log.LogWarningFromException(securityEx);
+            }
         }
         #endregion
     }

--- a/src/AM.Condo/Tasks/SaveFile.cs
+++ b/src/AM.Condo/Tasks/SaveFile.cs
@@ -1,0 +1,123 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SaveFile.cs" company="automotiveMastermind and contributors">
+//   © automotiveMastermind and contributors. Licensed under MIT. See LICENSE and CREDITS for details.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace AM.Condo.Tasks
+{
+    using System;
+    using System.IO;
+    using System.Security;
+    using System.Text;
+
+    using Microsoft.Build.Framework;
+    using Microsoft.Build.Utilities;
+
+    /// <summary>
+    /// Represents a Microsoft Build task used to save a file to disk with its contents.
+    /// </summary>
+    public class SaveFile : Task
+    {
+        #region Properties and Indexers
+        /// <summary>
+        /// Gets or sets the path of the file to save.
+        /// </summary>
+        [Required]
+        [Output]
+        public string FilePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the root of the repository.
+        /// </summary>
+        public string RepositoryRoot { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content of the file.
+        /// </summary>
+        public string Content { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not to replace the file if it already exists.
+        /// </summary>
+        public bool Replace { get; set; } = false;
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Executes the <see cref="SaveFile"/> task.
+        /// </summary>
+        /// <returns>
+        /// A value indicating whether or not the task was successful.
+        /// </returns>
+        public override bool Execute()
+        {
+            // determine if the contents are null
+            if (this.Content == null)
+            {
+                // set the contents to an empty string
+                this.Content = string.Empty;
+            }
+
+            try
+            {
+                // determine if the path is not rooted
+                if (!Path.IsPathRooted(this.FilePath))
+                {
+                    // combine the file path
+                    this.FilePath = Path.Combine(this.RepositoryRoot, this.FilePath);
+                }
+
+                // determine if the file already exists
+                if (File.Exists(this.FilePath))
+                {
+                    // determine if the file can be replaced
+                    if (this.Replace)
+                    {
+                        // delete the file
+                        File.Delete(this.FilePath);
+                    }
+                    else
+                    {
+                        // write a warning
+                        this.Log.LogWarning($"A file at the path: {this.FilePath} already exists and cannot be replaced.");
+
+                        // move on immediately
+                        return true;
+                    }
+                }
+
+                // write the file content to the specified path
+                File.WriteAllText(this.FilePath, this.Content, Encoding.UTF8);
+            }
+            catch (ArgumentException argEx)
+            {
+                // log a warning
+                this.Log.LogErrorFromException(argEx);
+
+                // move on immediately
+                return false;
+            }
+            catch (IOException ioEx)
+            {
+                // log the exception
+                this.Log.LogErrorFromException(ioEx);
+
+                // move on immediately
+                return false;
+            }
+            catch (SecurityException securityEx)
+            {
+                // log the exception
+                this.Log.LogErrorFromException(securityEx);
+
+                // move on immediately
+                return false;
+            }
+
+            // we were successful
+            return true;
+        }
+        #endregion
+    }
+}

--- a/src/AM.Condo/Tasks/SetEnvironmentVariable.cs
+++ b/src/AM.Condo/Tasks/SetEnvironmentVariable.cs
@@ -1,0 +1,64 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SetEnvironmentVariable.cs" company="automotiveMastermind and contributors">
+//   © automotiveMastermind and contributors. Licensed under MIT. See LICENSE and CREDITS for details.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace AM.Condo.Tasks
+{
+    using System;
+    using System.Security;
+
+    using Microsoft.Build.Framework;
+    using Microsoft.Build.Utilities;
+
+    /// <summary>
+    /// Represents a Microsoft Build task that sets an environment variable to the specified value.
+    /// </summary>
+    public class SetEnvironmentVariable : Task
+    {
+        #region Properties and Indexers
+        /// <summary>
+        /// Gets or sets the name of the variable to set.
+        /// </summary>
+        [Required]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value of the variable to set.
+        /// </summary>
+        [Required]
+        public string Value { get; set; }
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Executes the <see cref="SetEnvironmentVariable"/> task.
+        /// </summary>
+        /// <returns>
+        /// A value indicating whether or not the task executed successfully.
+        /// </returns>
+        public override bool Execute()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable(this.Name, this.Value);
+            }
+            catch (ArgumentException argEx)
+            {
+                this.Log.LogErrorFromException(argEx);
+
+                return false;
+            }
+            catch (SecurityException securityEx)
+            {
+                this.Log.LogErrorFromException(securityEx);
+
+                return false;
+            }
+
+            return true;
+        }
+        #endregion
+    }
+}

--- a/test/AM.Condo.Test/Tasks/RecommendVersionTest.cs
+++ b/test/AM.Condo.Test/Tasks/RecommendVersionTest.cs
@@ -95,12 +95,22 @@ namespace AM.Condo.Tasks
             // act
             var result = actual.Execute();
 
+            var currentVersionVariable = Environment.GetEnvironmentVariable(nameof(release.CurrentVersion));
+            var currentReleaseVariable = Environment.GetEnvironmentVariable(nameof(release.CurrentRelease));
+            var recommendedReleaseVariable = Environment.GetEnvironmentVariable(nameof(release.RecommendedRelease));
+            var nextReleaseVariable = Environment.GetEnvironmentVariable(nameof(release.NextRelease));
+
             // assert
             Assert.True(result);
             Assert.Equal(release.CurrentVersion ?? "0.0.0", actual.CurrentVersion);
             Assert.Equal(release.CurrentRelease, actual.CurrentRelease);
             Assert.Equal(release.RecommendedRelease, actual.RecommendedRelease);
             Assert.Equal(release.NextRelease, actual.NextRelease);
+
+            Assert.Equal(release.CurrentVersion ?? "0.0.0", currentVersionVariable);
+            Assert.Equal(release.CurrentRelease, currentReleaseVariable);
+            Assert.Equal(release.RecommendedRelease, recommendedReleaseVariable);
+            Assert.Equal(release.NextRelease, nextReleaseVariable);
         }
 
         public static TheoryData<ReleaseData> Releases => new TheoryData<ReleaseData>

--- a/test/AM.Condo.Test/Tasks/SaveFileTest.cs
+++ b/test/AM.Condo.Test/Tasks/SaveFileTest.cs
@@ -1,0 +1,150 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SaveFileTest.cs" company="automotiveMastermind and contributors">
+//   © automotiveMastermind and contributors. Licensed under MIT. See LICENSE and CREDITS for details.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace AM.Condo.Tasks
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using AM.Condo.IO;
+    using Microsoft.Build.Framework;
+    using Moq;
+    using Xunit;
+
+    [Priority(3)]
+    [Purpose(PurposeType.Unit)]
+    public class SaveFileTest
+    {
+        [Fact]
+        public void Execute_WhenFileDoesNotExistAndNoContent_SavesEmptyFile()
+        {
+            using (var temp = new TemporaryPath())
+            {
+                // arrange
+                var repositoryRoot = temp.FullPath;
+                var filePath = nameof(Execute_WhenFileDoesNotExistAndNoContent_SavesEmptyFile);
+                var content = default(string);
+                var replace = true;
+
+                var target = new SaveFile
+                {
+                    RepositoryRoot = repositoryRoot,
+                    FilePath = filePath,
+                    Content = content,
+                    Replace = replace
+                };
+
+                // act
+                var result = target.Execute();
+
+                // assert
+                Assert.True(result);
+                Assert.True(File.Exists(target.FilePath));
+
+                var actualContent = File.ReadAllText(target.FilePath);
+                Assert.Equal(string.Empty, actualContent);
+            }
+        }
+
+        [Fact]
+        public void Execute_WhenFileDoesNotExist_SavesFileWithContent()
+        {
+            using (var temp = new TemporaryPath())
+            {
+                // arrange
+                var repositoryRoot = temp.FullPath;
+                var path = nameof(Execute_WhenFileDoesNotExist_SavesFileWithContent);
+                var content = "Bar";
+                var replace = true;
+
+                var target = new SaveFile
+                {
+                    RepositoryRoot = repositoryRoot,
+                    FilePath = path,
+                    Content = content,
+                    Replace = replace
+                };
+
+                // act
+                var result = target.Execute();
+
+                // assert
+                Assert.True(result);
+                Assert.True(File.Exists(target.FilePath));
+
+                var actualContent = File.ReadAllText(target.FilePath);
+                Assert.Equal(content, actualContent);
+            }
+        }
+
+        [Fact]
+        public void Execute_WhenFileExistsAndReplacementAllowed_ReplacesFileWithContent()
+        {
+            using (var temp = new TemporaryPath())
+            {
+                // arrange
+                var repositoryRoot = temp.FullPath;
+                var path = nameof(Execute_WhenFileExistsAndReplacementAllowed_ReplacesFileWithContent);
+                var content = "Bar";
+                var replace = true;
+
+                File.Create(Path.Combine(repositoryRoot, path)).Dispose();
+
+                var target = new SaveFile
+                {
+                    RepositoryRoot = repositoryRoot,
+                    FilePath = path,
+                    Content = content,
+                    Replace = replace
+                };
+
+                // act
+                var result = target.Execute();
+
+                // assert
+                Assert.True(result);
+                Assert.True(File.Exists(target.FilePath));
+
+                var actualContent = File.ReadAllText(target.FilePath);
+                Assert.Equal(content, actualContent);
+            }
+        }
+
+        [Fact]
+        public void Execute_WhenFileExistsAndReplacementNotAllowed_LogsWarning()
+        {
+            using (var temp = new TemporaryPath())
+            {
+                // arrange
+                var repositoryRoot = temp.FullPath;
+                var path = nameof(Execute_WhenFileExistsAndReplacementNotAllowed_LogsWarning);
+                var content = default(string);
+                var replace = false;
+
+                File.Create(Path.Combine(repositoryRoot, path)).Dispose();
+
+                var engine = new Mock<IBuildEngine>();
+
+                engine.Setup(mock => mock.LogWarningEvent(It.IsAny<BuildWarningEventArgs>()));
+
+                var target = new SaveFile
+                {
+                    BuildEngine = engine.Object,
+                    RepositoryRoot = repositoryRoot,
+                    FilePath = path,
+                    Content = content,
+                    Replace = replace
+                };
+
+                // act
+                var result = target.Execute();
+
+                // assert
+                Assert.True(result);
+                engine.Verify(mock => mock.LogWarningEvent(It.IsAny<BuildWarningEventArgs>()), Times.Exactly(1));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add support for emitting environment variables for the following:
* BuildQuality
* CurrentVersion
* CurrentRelease
* RecommendedRelease
* NextRelease

To work around the lack of the ability to set environment variables at the machine and/or user level in *nix environments, add support for saving files with arbitrary names and content to allow external processes to access environment variables or other content produced by condo.

Related: #110 