### PR TITLE
feat(dotnet): add .net core 2.0 support

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,10 @@
 {
   "$schema": "http://json.schemastore.org/global",
+  "projects": [
+    "src",
+    "test"
+  ],
   "sdk": {
-    "version": "1.0.4"
+    "version": "2.0.0"
   }
 }

--- a/src/AM.Condo.Abstractions/AM.Condo.Abstractions.csproj
+++ b/src/AM.Condo.Abstractions/AM.Condo.Abstractions.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="System.Runtime.Extensions" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="System.Collections" Version="[4.3.0, 5.0.0)" />
-    <PackageReference Include="NuGet.Versioning" Version="[4.0.0, 5.0.0)" />
+    <PackageReference Include="NuGet.Versioning" Version="[4.3.0, 5.0.0)" />
 
     <PackageReference Include="StyleCop.Analyzers" Version="[1.0.2, 2.0.0)">
         <PrivateAssets>All</PrivateAssets>

--- a/src/AM.Condo.ChangeLog/AM.Condo.ChangeLog.csproj
+++ b/src/AM.Condo.ChangeLog/AM.Condo.ChangeLog.csproj
@@ -19,9 +19,7 @@
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.Process" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="Handlebars.NetStandard" Version="[1.8.1, 2.0.0)" />
-    <PackageReference Include="Newtonsoft.Json" Version="[9.0.1, 11.0.0)" />
-
-    <PackageReference Include="Newtonsoft.Json" Version="[10.0.2, 11.0.0)" />
+    <PackageReference Include="Newtonsoft.Json" Version="[10.0.3, 11.0.0)" />
     <PackageReference Include="StyleCop.Analyzers" Version="[1.0.2, 2.0.0)">
         <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/AM.Condo.IO/AM.Condo.IO.csproj
+++ b/src/AM.Condo.IO/AM.Condo.IO.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="System.Net.NameResolution" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="System.Linq" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.0, 5.0.0)" />
-    <PackageReference Include="NuGet.Versioning" Version="[4.0.0, 5.0.0)" />
+    <PackageReference Include="NuGet.Versioning" Version="[4.3.0, 5.0.0)" />
 
     <PackageReference Include="StyleCop.Analyzers" Version="[1.0.2, 2.0.0)">
         <PrivateAssets>All</PrivateAssets>

--- a/src/AM.Condo/AM.Condo.csproj
+++ b/src/AM.Condo/AM.Condo.csproj
@@ -7,7 +7,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputType>Exe</OutputType>
-    <RuntimeFrameworkVersion>[1.1.2, 2.0.0)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>[1.1.2, 3.0.0)</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,16 +31,15 @@
   <ItemGroup>
     <PackageReference Include="System.Dynamic.Runtime" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="System.IO.FileSystem" Version="[4.3.0, 5.0.0)" />
-    <PackageReference Include="Newtonsoft.Json" Version="[9.0.1, 11.0.0)" />
-    <PackageReference Include="NuGet.CommandLine.Xplat" Version="[4.0.0-rtm-*, 5.0.0)" />
-    <PackageReference Include="NuGet.Commands" Version="[4.0.0, 5.0.0)" />
-    <PackageReference Include="NuGet.Packaging" Version="[4.0.0, 5.0.0)" />
-    <PackageReference Include="NuGet.Versioning" Version="[4.0.0, 5.0.0)" />
-    <PackageReference Include="Microsoft.Build" Version="[15.1.1012, 16.0.0)" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="[15.1.1012, 16.0.0)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="[15.1.1012, 16.0.0)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="[15.1.1012, 16.0.0)" />
-
+    <PackageReference Include="Newtonsoft.Json" Version="[10.0.3, 11.0.0)" />
+    <PackageReference Include="NuGet.CommandLine.Xplat" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="NuGet.Commands" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="NuGet.Packaging" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="NuGet.Versioning" Version="[4.3.0, 5.0.0)" />
+    <PackageReference Include="Microsoft.Build" Version="[15.3.409, 16.0.0)" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="[15.3.409, 16.0.0)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="[15.3.409, 16.0.0)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="[15.3.409, 16.0.0)" />
     <PackageReference Include="StyleCop.Analyzers" Version="[1.0.2, 2.0.0)">
         <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/AM.Condo/NuGetActionLogger.cs
+++ b/src/AM.Condo/NuGetActionLogger.cs
@@ -8,7 +8,7 @@ namespace AM.Condo
 {
     using System;
     using System.Collections.Generic;
-
+    using System.Threading.Tasks;
     using NuGet.Common;
 
     /// <summary>
@@ -21,96 +21,77 @@ namespace AM.Condo
         #endregion
 
         #region Methods
-        /// <summary>
-        /// Logs the specified <paramref name="data"/> as a debug message.
-        /// </summary>
-        /// <param name="data">
-        /// The data that should be logged.
-        /// </param>
+        /// <inheritdoc />
+        public void Log(LogLevel level, string data)
+        {
+            this.actions.Add(logger => logger.Log(level, data));
+        }
+
+        /// <inheritdoc />
+        public void Log(ILogMessage message)
+        {
+            this.actions.Add(logger => logger.Log(message));
+        }
+
+        /// <inheritdoc />
+        public Task LogAsync(LogLevel level, string data)
+        {
+            this.actions.Add(logger => logger.Log(level, data));
+
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        public Task LogAsync(ILogMessage message)
+        {
+            this.actions.Add(logger => logger.Log(message));
+
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
         public void LogDebug(string data)
         {
             // add an action for logging a debug message
             this.actions.Add(logger => logger.LogDebug(data));
         }
 
-        /// <summary>
-        /// Logs the specified <paramref name="data"/> as an error.
-        /// </summary>
-        /// <param name="data">
-        /// The data that should be logged.
-        /// </param>
+        /// <inheritdoc />
         public void LogError(string data)
         {
             // add an action for logging a debug message
             this.actions.Add(logger => logger.LogDebug(data));
         }
 
-        /// <summary>
-        /// Logs the specified <paramref name="data"/> as an error summary.
-        /// </summary>
-        /// <param name="data">
-        /// The data that should be logged.
-        /// </param>
-        public void LogErrorSummary(string data)
-        {
-            // add an action for logging a debug message
-            this.actions.Add(logger => logger.LogDebug(data));
-        }
-
-        /// <summary>
-        /// Logs the specified <paramref name="data"/> as an information message.
-        /// </summary>
-        /// <param name="data">
-        /// The data that should be logged.
-        /// </param>
+        /// <inheritdoc />
         public void LogInformation(string data)
         {
             // add an action for logging a debug message
             this.actions.Add(logger => logger.LogDebug(data));
         }
 
-        /// <summary>
-        /// Logs the specified <paramref name="data"/> as an information summary.
-        /// </summary>
-        /// <param name="data">
-        /// The data that should be logged.
-        /// </param>
+        /// <inheritdoc />
         public void LogInformationSummary(string data)
         {
             // add an action for logging a debug message
             this.actions.Add(logger => logger.LogDebug(data));
         }
 
-        /// <summary>
-        /// Logs the specified <paramref name="data"/> as a minimal message.
-        /// </summary>
-        /// <param name="data">
-        /// The data that should be logged.
-        /// </param>
+        /// <inheritdoc />
         public void LogMinimal(string data)
         {
             // add an action for logging a debug message
             this.actions.Add(logger => logger.LogDebug(data));
         }
 
-        /// <summary>
-        /// Logs the specified <paramref name="data"/> as a verbose message.
-        /// </summary>
-        /// <param name="data">
-        /// The data that should be logged.
-        /// </param>
+        /// <inheritdoc />
         public void LogVerbose(string data)
         {
             // add an action for logging a debug message
             this.actions.Add(logger => logger.LogDebug(data));
         }
 
-        /// <summary>
-        /// Logs the specified <paramref name="data"/> as a warning.
-        /// </summary>
-        /// <param name="data">
-        /// The data that should be logged.
-        /// </param>
+        /// <inheritdoc />
         public void LogWarning(string data)
         {
             // add an action for logging a debug message

--- a/src/AM.Condo/NuGetMSBuildLogger.cs
+++ b/src/AM.Condo/NuGetMSBuildLogger.cs
@@ -7,13 +7,17 @@
 namespace AM.Condo
 {
     using System;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     using Microsoft.Build.Framework;
     using Microsoft.Build.Utilities;
+    using NuGet.Common;
 
     using static System.FormattableString;
 
     using ILogger = NuGet.Common.ILogger;
+    using Task = System.Threading.Tasks.Task;
 
     /// <summary>
     /// Represents a NuGet logger that emits log messages to an underlying Microsoft Build log.
@@ -43,96 +47,80 @@ namespace AM.Condo
             // set the log
             this.log = log;
         }
+
+        /// <inheritdoc />
+        public void Log(LogLevel level, string data)
+        {
+            switch (level)
+            {
+                case LogLevel.Error:
+                    this.log.LogError(data);
+                    break;
+                case LogLevel.Warning:
+                    this.log.LogWarning(data);
+                    break;
+                default:
+                    this.log.LogMessage(MessageImportance.Low, data);
+                    break;
+            }
+        }
+
+        /// <inheritdoc />
+        public void Log(ILogMessage message)
+        {
+            this.Log(message.Level, message.Message);
+        }
+
+        /// <inheritdoc />
+        public Task LogAsync(LogLevel level, string data)
+        {
+            return Task.Run(() => this.Log(level, data));
+        }
+
+        /// <inheritdoc />
+        public Task LogAsync(ILogMessage message)
+        {
+            return Task.Run(() => this.Log(message.Level, message.Message));
+        }
         #endregion
 
         #region Methods
-        /// <summary>
-        /// Logs the specified <paramref name="data"/> as a debug message.
-        /// </summary>
-        /// <param name="data">
-        /// The data that should be logged.
-        /// </param>
+        /// <inheritdoc />
         public void LogDebug(string data)
         {
             this.log.LogMessage(MessageImportance.Low, data);
         }
 
-        /// <summary>
-        /// Logs the specified <paramref name="data"/> as an error.
-        /// </summary>
-        /// <param name="data">
-        /// The data that should be logged.
-        /// </param>
+        /// <inheritdoc />
         public void LogError(string data)
         {
             this.log.LogError(data);
         }
 
-        /// <summary>
-        /// Logs the specified <paramref name="data"/> as an error summary.
-        /// </summary>
-        /// <param name="data">
-        /// The data that should be logged.
-        /// </param>
-        /// <remarks>
-        /// This is a no-op as Microsoft Build already provides summary information.
-        /// </remarks>
-        public void LogErrorSummary(string data)
-        {
-        }
-
-        /// <summary>
-        /// Logs the specified <paramref name="data"/> as an information message.
-        /// </summary>
-        /// <param name="data">
-        /// The data that should be logged.
-        /// </param>
+        /// <inheritdoc />
         public void LogInformation(string data)
         {
             this.log.LogMessage(data);
         }
 
-        /// <summary>
-        /// Logs the specified <paramref name="data"/> as an information summary.
-        /// </summary>
-        /// <param name="data">
-        /// The data that should be logged.
-        /// </param>
-        /// <remarks>
-        /// This is a no-op as Microsoft Build already provides summary information.
-        /// </remarks>
+        /// <inheritdoc />
         public void LogInformationSummary(string data)
         {
         }
 
-        /// <summary>
-        /// Logs the specified <paramref name="data"/> as a minimal message.
-        /// </summary>
-        /// <param name="data">
-        /// The data that should be logged.
-        /// </param>
+        /// <inheritdoc />
         public void LogMinimal(string data)
         {
             this.log.LogMessage(MessageImportance.High, data);
         }
 
-        /// <summary>
-        /// Logs the specified <paramref name="data"/> as a verbose message.
-        /// </summary>
-        /// <param name="data">
-        /// The data that should be logged.
-        /// </param>
+        /// <inheritdoc />
         public void LogVerbose(string data)
         {
             this.log.LogMessage(MessageImportance.Low, data);
         }
 
-        /// <summary>
-        /// Logs the specified <paramref name="data"/> as a warning.
-        /// </summary>
-        /// <param name="data">
-        /// The data that should be logged.
-        /// </param>
+        /// <inheritdoc />
         public void LogWarning(string data)
         {
             this.log.LogWarning(data);

--- a/src/AM.Condo/Scripts/condo.sh
+++ b/src/AM.Condo/Scripts/condo.sh
@@ -193,13 +193,13 @@ done
 # determine if the dotnet install url is not already set
 if [ -z "$DOTNET_INSTALL_URL" ]; then
     # set the dotnet install url to the 1.0.1 release
-    DOTNET_INSTALL_URL="https://github.com/dotnet/cli/raw/rel/1.0.1/scripts/obtain/dotnet-install.sh"
+    DOTNET_INSTALL_URL="https://github.com/dotnet/cli/raw/release/2.0.0/scripts/obtain/dotnet-install.sh"
 fi
 
 # determine if the dotnet install channel is not already set
 if [ -z "${DOTNET_CHANNEL:-}" ]; then
     # set the dotnet channel
-    DOTNET_CHANNEL="release/1.0.0"
+    DOTNET_CHANNEL="release/2.0.0"
 fi
 
 [ ! -d "$BUILD_ROOT" ] && mkdir -p $BUILD_ROOT
@@ -234,4 +234,5 @@ info "Starting build..."
 info "msbuild '$CONDO_PROJ'"
 
 dotnet msbuild @"$MSBUILD_RSP"
+
 safe-exit $?

--- a/test/AM.Condo.E2E.Test/AM.Condo.E2E.Test.csproj
+++ b/test/AM.Condo.E2E.Test/AM.Condo.E2E.Test.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <DebugType>portable</DebugType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <RuntimeFrameworkVersion>[1.1.2, 2.0.0)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>[2.0.0, 3.0.0)</RuntimeFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/AM.Condo/AM.Condo.csproj" />
     <ProjectReference Include="../../src/AM.Condo.Xunit/AM.Condo.Xunit.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[15.0.0, 16.0.0)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[15.3.0, 16.0.0)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="xunit" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Moq" Version="[4.7.12, 5.0.0)" />
+    <PackageReference Include="Moq" Version="[4.7.99, 5.0.0)" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/AM.Condo.IO.Test/AM.Condo.IO.Test.csproj
+++ b/test/AM.Condo.IO.Test/AM.Condo.IO.Test.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <DebugType>portable</DebugType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <RuntimeFrameworkVersion>[1.1.2, 2.0.0)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>[2.0.0, 3.0.0)</RuntimeFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/AM.Condo.IO/AM.Condo.IO.csproj" />
     <ProjectReference Include="../../src/AM.Condo.Xunit/AM.Condo.Xunit.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[15.0.0, 16.0.0)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[15.3.0, 16.0.0)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="xunit" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Moq" Version="[4.7.12, 5.0.0)" />
+    <PackageReference Include="Moq" Version="[4.7.99, 5.0.0)" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/AM.Condo.Test/AM.Condo.Test.csproj
+++ b/test/AM.Condo.Test/AM.Condo.Test.csproj
@@ -1,26 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <DebugType>portable</DebugType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <RuntimeFrameworkVersion>[1.1.2, 2.0.0)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>[2.0.0, 3.0.0)</RuntimeFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/AM.Condo/AM.Condo.csproj" />
     <ProjectReference Include="../../src/AM.Condo.Xunit/AM.Condo.Xunit.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[15.0.0, 16.0.0)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[15.3.0, 16.0.0)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="[2.2.0, 3.0.0)" />
     <PackageReference Include="xunit" Version="[2.2.0, 3.0.0)" />
-    <PackageReference Include="Moq" Version="[4.7.12, 5.0.0)" />
+    <PackageReference Include="Moq" Version="[4.7.99, 5.0.0)" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="[1.0.1, 2.0.0)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
BREAKING CHANGE:

This build will break support for the .NET Core 1.x SDK and will live within a new branch naming scheme of netcore/2. The current develop version will be published to netcore/1.