### PR TITLE
feat(dotnet): add support for legacy .net framework

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,5 @@ indent_size = 4
 char_set = utf-8
 insert_final_newline = true
 
-[*.{js,json,targets,html}]
+[*.{js,json,targets,html,csproj}]
 indent_size = 2

--- a/src/AM.Condo.Xunit/AM.Condo.Xunit.csproj
+++ b/src/AM.Condo.Xunit/AM.Condo.Xunit.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="System.Diagnostics.Process" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="System.Net.NameResolution" Version="[4.3.0, 5.0.0)" />
     <PackageReference Include="System.Threading.Thread" Version="[4.3.0, 5.0.0)" />
-    <PackageReference Include="xunit" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="xunit" Version="[2.3.1, 3.0.0)" />
 
     <PackageReference Include="StyleCop.Analyzers" Version="[1.0.2, 2.0.0)">
         <PrivateAssets>All</PrivateAssets>

--- a/src/AM.Condo/Targets/Clean.targets
+++ b/src/AM.Condo/Targets/Clean.targets
@@ -10,7 +10,7 @@
       <Projects Include="$(RepositoryRoot)**$(slash)*.*proj" />
     </ItemGroup>
 
-    <GetProjectMetadata Projects="@(Projects)">
+    <GetProjectMetadata Projects="@(Projects)" Product="$(Product)">
       <Output TaskParameter="Projects" ItemName="CleanProjects" />
     </GetProjectMetadata>
 

--- a/src/AM.Condo/Targets/Clean.targets
+++ b/src/AM.Condo/Targets/Clean.targets
@@ -10,7 +10,7 @@
       <Projects Include="$(RepositoryRoot)**$(slash)*.*proj" />
     </ItemGroup>
 
-    <GetProjectMetadata Projects="@(Projects)" Product="$(Product)">
+    <GetProjectMetadata Projects="@(Projects)" Product="$(Product)" RepositoryRoot="$(RepositoryRoot)">
       <Output TaskParameter="Projects" ItemName="CleanProjects" />
     </GetProjectMetadata>
 

--- a/src/AM.Condo/Targets/Prepare/Bower.targets
+++ b/src/AM.Condo/Targets/Prepare/Bower.targets
@@ -27,7 +27,7 @@
     <Warning Condition=" !$(HasBower) AND $(BowerRequired) "
              Text="A bower.json file was located at: %(BowerJsonPaths.Identity), but the bower command or executable could not be found." />
 
-    <GetProjectMetadata Projects="@(BowerJsonPaths)">
+    <GetProjectMetadata Projects="@(BowerJsonPaths)" Product="$(Product)">
       <Output TaskParameter="Projects" ItemName="BowerJsonProjects" />
     </GetProjectMetadata>
   </Target>

--- a/src/AM.Condo/Targets/Prepare/Bower.targets
+++ b/src/AM.Condo/Targets/Prepare/Bower.targets
@@ -27,7 +27,7 @@
     <Warning Condition=" !$(HasBower) AND $(BowerRequired) "
              Text="A bower.json file was located at: %(BowerJsonPaths.Identity), but the bower command or executable could not be found." />
 
-    <GetProjectMetadata Projects="@(BowerJsonPaths)" Product="$(Product)">
+    <GetProjectMetadata Projects="@(BowerJsonPaths)" Product="$(Product)" RepositoryRoot="$(RepositoryRoot)">
       <Output TaskParameter="Projects" ItemName="BowerJsonProjects" />
     </GetProjectMetadata>
   </Target>

--- a/src/AM.Condo/Targets/Prepare/Bower.targets
+++ b/src/AM.Condo/Targets/Prepare/Bower.targets
@@ -39,6 +39,8 @@
   <Target Name="BowerInstall" Condition=" $(BowerInstall) ">
     <PropertyGroup>
       <BowerInstallOptions Condition=" '$(BowerInstallOptions)' == '' ">$(BOWER_INSTALL_OPTIONS)</BowerInstallOptions>
+      <BowerInstallOptions>$(BowerInstallOptions) --allow-root</BowerInstallOptions>
+      <BowerInstallOptions>$(BowerInstallOptions.Trim())</BowerInstallOptions>
     </PropertyGroup>
 
     <Exec Command="&quot;$(BowerPath)&quot; install $(BowerInstallOptions.Trim())"

--- a/src/AM.Condo/Targets/Prepare/Docker.targets
+++ b/src/AM.Condo/Targets/Prepare/Docker.targets
@@ -54,11 +54,11 @@
     <Warning Condition="!$(HasDocker) AND $(DockerComposeRequired) "
              Text="A docker-compose file was located at: %(DockerComposePaths.Identity), but the docker command or executable could not be found." />
 
-    <DockerLabel
+    <GetDockerMetadata
         DockerFiles="@(DockerfilePaths)"
         BuildQuality="$(BuildQuality)"
         Version="$(InformationalVersion)"
-        Label="$(DockerLabel)"
+        Product="$(Product)"
         Condition=" $(DockerBuild) ">
       <Output TaskParameter="DockerFiles" ItemName="DockerMetadata" />
     </GetDockerMetadata>

--- a/src/AM.Condo/Targets/Prepare/Docker.targets
+++ b/src/AM.Condo/Targets/Prepare/Docker.targets
@@ -54,10 +54,11 @@
     <Warning Condition="!$(HasDocker) AND $(DockerComposeRequired) "
              Text="A docker-compose file was located at: %(DockerComposePaths.Identity), but the docker command or executable could not be found." />
 
-    <GetDockerMetadata
+    <DockerLabel
         DockerFiles="@(DockerfilePaths)"
         BuildQuality="$(BuildQuality)"
         Version="$(InformationalVersion)"
+        Label="$(DockerLabel)"
         Condition=" $(DockerBuild) ">
       <Output TaskParameter="DockerFiles" ItemName="DockerMetadata" />
     </GetDockerMetadata>

--- a/src/AM.Condo/Targets/Prepare/Docker.targets
+++ b/src/AM.Condo/Targets/Prepare/Docker.targets
@@ -46,6 +46,9 @@
       <DockerPush Condition=" '$(DockerPush)' != '' AND '$(DockerPush.ToLower())' != 'true' ">false</DockerPush>
       <DockerPush Condition=" '$(DockerPush)' == '' AND $(DockerBuild) AND '$(DockerOrganization)' != '' ">true</DockerPush>
       <DockerPush Condition=" '$(DockerPush)' == '' ">false</DockerPush>
+
+      <DockerEnableExtendedTags Condition=" '$(DockerEnableExtendedTags)' == '' ">$(DOCKER_ENABLE_EXTENDED_TAGS)</DockerEnableExtendedTags>
+      <DockerEnableExtendedTags Condition=" '$(DockerEnableExtendedTags)' == '' ">false</DockerEnableExtendedTags>
     </PropertyGroup>
 
     <Warning Condition="!$(HasDocker) AND $(DockerBuildRequired) "
@@ -60,6 +63,7 @@
         Version="$(InformationalVersion)"
         Product="$(Product)"
         RepositoryRoot="$(RepositoryRoot)"
+        EnableExtendedTags="$(DockerEnableExtendedTags)"
         Condition=" $(DockerBuild) ">
       <Output TaskParameter="DockerFiles" ItemName="DockerMetadata" />
     </GetDockerMetadata>

--- a/src/AM.Condo/Targets/Prepare/Docker.targets
+++ b/src/AM.Condo/Targets/Prepare/Docker.targets
@@ -59,6 +59,7 @@
         BuildQuality="$(BuildQuality)"
         Version="$(InformationalVersion)"
         Product="$(Product)"
+        RepositoryRoot="$(RepositoryRoot)"
         Condition=" $(DockerBuild) ">
       <Output TaskParameter="DockerFiles" ItemName="DockerMetadata" />
     </GetDockerMetadata>

--- a/src/AM.Condo/Targets/Prepare/Dotnet.targets
+++ b/src/AM.Condo/Targets/Prepare/Dotnet.targets
@@ -35,7 +35,7 @@
       <DotNetPublish Condition=" '$(DotNetPublish)' == '' ">true</DotNetPublish>
     </PropertyGroup>
 
-    <GetProjectMetadata Projects="@(DotNetProjects)" Product="$(Product)"
+    <GetProjectMetadata Projects="@(DotNetProjects)" Product="$(Product)" RepositoryRoot="$(RepositoryRoot)"
       Restore="$(DotNetRestore)" Build="$(DotNetBuild)" Pack="$(DotNetPack)" Test="$(DotNetTest)" Publish="$(DotNetPublish)">
       <Output TaskParameter="Projects" ItemName="DotNetMetadata" />
     </GetProjectMetadata>

--- a/src/AM.Condo/Targets/Prepare/Dotnet.targets
+++ b/src/AM.Condo/Targets/Prepare/Dotnet.targets
@@ -63,7 +63,6 @@
       <DotNetRestoreProperties Condition=" '$(InformationalVersion)' != '' ">$(DotNetRestoreProperties);Version=$(InformationalVersion)</DotNetRestoreProperties>
     </PropertyGroup>
 
-
     <MSBuild Projects="@(RestoreProjects)" Properties="$(DotNetRestoreProperties)" Targets="Restore" />
   </Target>
 

--- a/src/AM.Condo/Targets/Prepare/Dotnet.targets
+++ b/src/AM.Condo/Targets/Prepare/Dotnet.targets
@@ -35,7 +35,7 @@
       <DotNetPublish Condition=" '$(DotNetPublish)' == '' ">true</DotNetPublish>
     </PropertyGroup>
 
-    <GetProjectMetadata Projects="@(DotNetProjects)"
+    <GetProjectMetadata Projects="@(DotNetProjects)" Product="$(Product)"
       Restore="$(DotNetRestore)" Build="$(DotNetBuild)" Pack="$(DotNetPack)" Test="$(DotNetTest)" Publish="$(DotNetPublish)">
       <Output TaskParameter="Projects" ItemName="DotNetMetadata" />
     </GetProjectMetadata>

--- a/src/AM.Condo/Targets/Prepare/Dotnet.targets
+++ b/src/AM.Condo/Targets/Prepare/Dotnet.targets
@@ -41,6 +41,10 @@
     </GetProjectMetadata>
 
     <ItemGroup>
+      <DocFXProjects      Include="$(DocsRoot)**$(slash)docfx.json" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" @(DotNetMetadata->Count()) > 0 ">
       <RestoreProjects    Include="@(DotNetMetadata)"       Condition=" %(DotNetMetadata.IsRestorable) " />
       <BuildProjects      Include="@(DotNetMetadata)"       Condition=" %(DotNetMetadata.IsBuildable) " />
       <SourceProjects     Include="@(DotNetMetadata)"       Condition=" '%(DotNetMetadata.ProjectGroup)' == 'src' " />
@@ -48,8 +52,15 @@
       <SampleProjects     Include="@(DotNetMetadata)"       Condition=" '%(DotNetMetadata.ProjectGroup)' == 'samples' "/>
       <PublishProjects    Include="@(SourceProjects)"       Condition=" %(SourceProjects.IsPublishable) " />
       <PackProjects       Include="@(SourceProjects)"       Condition=" %(SourceProjects.IsPackable) " />
-      <DocFXProjects      Include="$(DocsRoot)**$(slash)docfx.json" />
     </ItemGroup>
+
+    <PropertyGroup>
+      <DotNetRestore Condition=" @(RestoreProjects->Count()) == 0 ">false</DotNetRestore>
+      <DotNetBuild Condition=" @(SourceProjects->Count()) == 0 ">false</DotNetBuild>
+      <DotNetPack Condition=" @(PackProjects->Count()) == 0 ">false</DotNetPack>
+      <DotNetTest Condition=" @(TestProjects->Count()) == 0 ">false</DotNetTest>
+      <DotNetPublish Condition=" @(PublishProjects->Count()) == 0 ">false</DotNetPublish>
+    </PropertyGroup>
   </Target>
 
   <Target Name="PrintDotNetProjects" Condition=" $(DotNetBuild) OR $(DotNetPack) OR $(DotNetTest) OR $(DotNetPublish) ">

--- a/src/AM.Condo/Targets/Prepare/Npm.targets
+++ b/src/AM.Condo/Targets/Prepare/Npm.targets
@@ -26,7 +26,7 @@
       <NpmInstall Condition=" '$(NpmInstall)' == '' ">false</NpmInstall>
     </PropertyGroup>
 
-    <GetProjectMetadata Projects="@(PackageJsonPaths)" Product="$(Product)">
+    <GetProjectMetadata Projects="@(PackageJsonPaths)" Product="$(Product)" RepositoryRoot="$(RepositoryRoot)">
       <Output TaskParameter="Projects" ItemName="PackageJsonProjects" />
     </GetProjectMetadata>
 

--- a/src/AM.Condo/Targets/Prepare/Npm.targets
+++ b/src/AM.Condo/Targets/Prepare/Npm.targets
@@ -26,7 +26,7 @@
       <NpmInstall Condition=" '$(NpmInstall)' == '' ">false</NpmInstall>
     </PropertyGroup>
 
-    <GetProjectMetadata Projects="@(PackageJsonPaths)">
+    <GetProjectMetadata Projects="@(PackageJsonPaths)" Product="$(Product)">
       <Output TaskParameter="Projects" ItemName="PackageJsonProjects" />
     </GetProjectMetadata>
 

--- a/src/AM.Condo/Targets/Prepare/Polymer.targets
+++ b/src/AM.Condo/Targets/Prepare/Polymer.targets
@@ -33,7 +33,7 @@
     <Warning Condition=" !$(HasPolymer) AND $(PolymerRequired) "
              Text="A polymer.json file was located at: %(PolymerJsonPaths.Identity), but the polymer command or executable could not be found." />
 
-    <GetProjectMetadata Projects="@(PolymerJsonPaths)" Product="$(Product)">
+    <GetProjectMetadata Projects="@(PolymerJsonPaths)" Product="$(Product)" RepositoryRoot="$(RepositoryRoot)">
       <Output TaskParameter="Projects" ItemName="PolymerJsonProjects" />
     </GetProjectMetadata>
   </Target>

--- a/src/AM.Condo/Targets/Prepare/Polymer.targets
+++ b/src/AM.Condo/Targets/Prepare/Polymer.targets
@@ -33,7 +33,7 @@
     <Warning Condition=" !$(HasPolymer) AND $(PolymerRequired) "
              Text="A polymer.json file was located at: %(PolymerJsonPaths.Identity), but the polymer command or executable could not be found." />
 
-    <GetProjectMetadata Projects="@(PolymerJsonPaths)">
+    <GetProjectMetadata Projects="@(PolymerJsonPaths)" Product="$(Product)">
       <Output TaskParameter="Projects" ItemName="PolymerJsonProjects" />
     </GetProjectMetadata>
   </Target>

--- a/src/AM.Condo/Targets/Publish/Dotnet.targets
+++ b/src/AM.Condo/Targets/Publish/Dotnet.targets
@@ -8,7 +8,7 @@
   <Target Name="DotNetPublish" Condition=" $(DotNetPublish) ">
     <ItemGroup>
       <_DotNetPublish Include="@(PublishProjects)">
-        <AdditionalProperties>%(AdditionalProperties);$(DotNetPublishProperties)</AdditionalProperties>
+        <AdditionalProperties>%(PublishProjects.AdditionalProperties);$(DotNetPublishProperties)</AdditionalProperties>
         <AdditionalProperties Condition=" '%(RuntimeIdentifier)' != '' ">%(_DotNetPublish.AdditionalProperties);RuntimeIdentifier=%(RuntimeIdentifier)</AdditionalProperties>
         <AdditionalProperties Condition=" '%(TargetFramework)' != '' ">%(_DotNetPublish.AdditionalProperties);TargetFramework=%(TargetFramework)</AdditionalProperties>
         <AdditionalProperties>%(_DotNetPublish.AdditionalProperties);PublishDir=%(OutputPath)</AdditionalProperties>

--- a/src/AM.Condo/Targets/Publish/Dotnet.targets
+++ b/src/AM.Condo/Targets/Publish/Dotnet.targets
@@ -8,7 +8,7 @@
   <Target Name="DotNetPublish" Condition=" $(DotNetPublish) ">
     <ItemGroup>
       <_DotNetPublish Include="@(PublishProjects)">
-        <AdditionalProperties>$(DotNetPublishProperties)</AdditionalProperties>
+        <AdditionalProperties>%(AdditionalProperties);$(DotNetPublishProperties)</AdditionalProperties>
         <AdditionalProperties Condition=" '%(RuntimeIdentifier)' != '' ">%(_DotNetPublish.AdditionalProperties);RuntimeIdentifier=%(RuntimeIdentifier)</AdditionalProperties>
         <AdditionalProperties Condition=" '%(TargetFramework)' != '' ">%(_DotNetPublish.AdditionalProperties);TargetFramework=%(TargetFramework)</AdditionalProperties>
         <AdditionalProperties>%(_DotNetPublish.AdditionalProperties);PublishDir=%(OutputPath)</AdditionalProperties>

--- a/src/AM.Condo/Targets/Test/Dotnet.targets
+++ b/src/AM.Condo/Targets/Test/Dotnet.targets
@@ -29,7 +29,7 @@
 
     <ItemGroup>
       <_DotNetTest Include="@(TestProjects)">
-        <AdditionalProperties>%(AdditionalProperties);$(DotNetTestProperties)</AdditionalProperties>
+        <AdditionalProperties>%(TestProjects.AdditionalProperties);$(DotNetTestProperties)</AdditionalProperties>
         <AdditionalProperties Condition=" '%(RuntimeIdentifier)' != '' ">%(_DotNetTest.AdditionalProperties);RuntimeIdentifier=%(RuntimeIdentifier)</AdditionalProperties>
         <AdditionalProperties Condition=" '%(TargetFramework)' != '' ">%(_DotNetTest.AdditionalProperties);TargetFramework=%(TargetFramework)</AdditionalProperties>
         <AdditionalProperties>%(_DotNetTest.AdditionalProperties);VSTestLogger=trx%3bLogFileName=%(TestLogFileName)</AdditionalProperties>

--- a/src/AM.Condo/Targets/Test/Dotnet.targets
+++ b/src/AM.Condo/Targets/Test/Dotnet.targets
@@ -29,11 +29,14 @@
 
     <ItemGroup>
       <_DotNetTest Include="@(TestProjects)">
-        <AdditionalProperties>VSTestLogger=trx%3bLogFileName=%(Filename).dotnet.xml</AdditionalProperties>
+        <AdditionalProperties>%(AdditionalProperties);$(DotNetTestProperties)</AdditionalProperties>
+        <AdditionalProperties Condition=" '%(RuntimeIdentifier)' != '' ">%(_DotNetTest.AdditionalProperties);RuntimeIdentifier=%(RuntimeIdentifier)</AdditionalProperties>
+        <AdditionalProperties Condition=" '%(TargetFramework)' != '' ">%(_DotNetTest.AdditionalProperties);TargetFramework=%(TargetFramework)</AdditionalProperties>
+        <AdditionalProperties>%(_DotNetTest.AdditionalProperties);VSTestLogger=trx%3bLogFileName=%(TestLogFileName)</AdditionalProperties>
       </_DotNetTest>
     </ItemGroup>
 
-    <MSBuild Projects="@(_DotNetTest)" Properties="$(DotNetTestProperties)" Targets="VSTest" />
+    <MSBuild Projects="@(_DotNetTest)" Targets="VSTest" />
   </Target>
 
   <PropertyGroup>

--- a/src/AM.Condo/Tasks/GetDockerMetadata.cs
+++ b/src/AM.Condo/Tasks/GetDockerMetadata.cs
@@ -53,6 +53,11 @@ namespace AM.Condo.Tasks
         /// </summary>
         [Required]
         public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not to enable extended tags.
+        /// </summary>
+        public bool EnableExtendedTags { get; set; }
         #endregion
 
         #region Methods
@@ -140,33 +145,38 @@ namespace AM.Condo.Tasks
             tags.Add("VersionTag", $"{this.Version}");
             labels.Add("VersionLabel", $"{dockerName}:{this.Version}");
 
-            if (string.IsNullOrEmpty(this.BuildQuality))
+            // determine if we should calculate extended tags
+            if (this.EnableExtendedTags)
             {
-                tags.Add("LatestTag", "latest");                            // :latest
-                labels.Add("LatestLabel", $"{dockerName}:latest");
+                // determine if the build quality is set
+                if (string.IsNullOrEmpty(this.BuildQuality))
+                {
+                    tags.Add("LatestTag", "latest");                            // :latest
+                    labels.Add("LatestLabel", $"{dockerName}:latest");
 
-                tags.Add("StableTag", "stable");                            // :stable
-                labels.Add("StableLabel", $"{dockerName}:stable");
+                    tags.Add("StableTag", "stable");                            // :stable
+                    labels.Add("StableLabel", $"{dockerName}:stable");
 
-                tags.Add("MajorTag", $"{version.Major}");                   // :1
-                labels.Add("MajorLabel", $"{dockerName}:{version.Major}");
+                    tags.Add("MajorTag", $"{version.Major}");                   // :1
+                    labels.Add("MajorLabel", $"{dockerName}:{version.Major}");
 
-                tags.Add("MinorTag", $"{version.Major}-{version.Minor}");   // :1.1
-                labels.Add("MinorLabel", $"{dockerName}:{version.Major}-{version.Minor}");
-            }
-            else
-            {
-                tags.Add("BuildQualityTag", this.BuildQuality);             // :beta
-                labels.Add("BuildQualityLabel", $"{dockerName}:{this.BuildQuality}");
+                    tags.Add("MinorTag", $"{version.Major}-{version.Minor}");   // :1.1
+                    labels.Add("MinorLabel", $"{dockerName}:{version.Major}-{version.Minor}");
+                }
+                else
+                {
+                    tags.Add("BuildQualityTag", this.BuildQuality);             // :beta
+                    labels.Add("BuildQualityLabel", $"{dockerName}:{this.BuildQuality}");
 
-                tags.Add("PrereleaseTag", "prerelease");                    // :prerelease
-                labels.Add("PrereleaseLabel", $"{dockerName}:prerelease");
+                    tags.Add("PrereleaseTag", "prerelease");                    // :prerelease
+                    labels.Add("PrereleaseLabel", $"{dockerName}:prerelease");
 
-                tags.Add("MajorTag", $"{version.Major}-{this.BuildQuality}");
-                labels.Add("MajorLabel", $"{dockerName}:{version.Major}-{this.BuildQuality}");
+                    tags.Add("MajorTag", $"{version.Major}-{this.BuildQuality}");
+                    labels.Add("MajorLabel", $"{dockerName}:{version.Major}-{this.BuildQuality}");
 
-                tags.Add("MinorTag", $"{version.Major}-{version.Minor}-{this.BuildQuality}");
-                labels.Add("MinorLabel", $"{dockerName}:{version.Major}-{version.Minor}-{this.BuildQuality}");
+                    tags.Add("MinorTag", $"{version.Major}-{version.Minor}-{this.BuildQuality}");
+                    labels.Add("MinorLabel", $"{dockerName}:{version.Major}-{version.Minor}-{this.BuildQuality}");
+                }
             }
 
             // get the extension (platform) of the dockerfile

--- a/src/AM.Condo/Tasks/GetDockerMetadata.cs
+++ b/src/AM.Condo/Tasks/GetDockerMetadata.cs
@@ -41,6 +41,11 @@ namespace AM.Condo.Tasks
         /// </summary>
         [Required]
         public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default label to use for docker images when present within the root folder.
+        /// </summary>
+        public string Label { get; set; }
         #endregion
 
         #region Methods
@@ -78,7 +83,7 @@ namespace AM.Condo.Tasks
             // get the directory name from the path
             var directory = Path.GetDirectoryName(path);
             var parent = Path.GetDirectoryName(directory);
-            var group = Path.GetFileName(directory);
+            var group = string.IsNullOrEmpty(this.Label) ? Path.GetFileName(directory) : this.Label;
 
             // get the docker file path
             var projectFile = Directory.GetFiles(directory, "*.*proj").FirstOrDefault();

--- a/src/AM.Condo/Tasks/GetDockerMetadata.cs
+++ b/src/AM.Condo/Tasks/GetDockerMetadata.cs
@@ -98,8 +98,8 @@ namespace AM.Condo.Tasks
             // determine if the project is rooted
             var rooted = string.Equals
             (
-                Path.GetFullPath(directory),
-                Path.GetFullPath(this.RepositoryRoot),
+                Path.GetFullPath(directory + Path.DirectorySeparatorChar),
+                Path.GetFullPath(this.RepositoryRoot + Path.DirectorySeparatorChar),
                 StringComparison.OrdinalIgnoreCase
             );
 

--- a/src/AM.Condo/Tasks/GetDockerMetadata.cs
+++ b/src/AM.Condo/Tasks/GetDockerMetadata.cs
@@ -31,6 +31,12 @@ namespace AM.Condo.Tasks
         public ITaskItem[] Dockerfiles { get; set; }
 
         /// <summary>
+        /// Gets or sets the product name to use when only a single project is present.
+        /// </summary>
+        [Required]
+        public string Product { get; set; }
+
+        /// <summary>
         /// Gets or sets the build quality associated with the tag.
         /// </summary>
         [Required]
@@ -41,11 +47,6 @@ namespace AM.Condo.Tasks
         /// </summary>
         [Required]
         public string Version { get; set; }
-
-        /// <summary>
-        /// Gets or sets the default label to use for docker images when present within the root folder.
-        /// </summary>
-        public string Label { get; set; }
         #endregion
 
         #region Methods
@@ -83,16 +84,22 @@ namespace AM.Condo.Tasks
             // get the directory name from the path
             var directory = Path.GetDirectoryName(path);
             var parent = Path.GetDirectoryName(directory);
-            var group = string.IsNullOrEmpty(this.Label) ? Path.GetFileName(directory) : this.Label;
+            var group = Path.GetFileName(directory);
+
+            // get the product name
+            var dockerName = !GetProjectMetadata.WellKnownFolders.Contains(group, StringComparer.OrdinalIgnoreCase)
+                ? group
+                : this.Product;
 
             // get the docker file path
             var projectFile = Directory.GetFiles(directory, "*.*proj").FirstOrDefault();
 
-            // get the name of the docker file from the project file sitting next to it; or from the parent folder name
-            // otherwise
-            var dockerName = string.IsNullOrEmpty(projectFile)
-                ? group
-                : Path.GetFileNameWithoutExtension(projectFile);
+            // determine if the project file existed
+            if (!string.IsNullOrEmpty(projectFile))
+            {
+                // use the name of the project as the docker name
+                dockerName = Path.GetFileNameWithoutExtension(projectFile);
+            }
 
             // calculate the label
             dockerName = dockerName.ToLower();

--- a/src/AM.Condo/Tasks/GetDockerMetadata.cs
+++ b/src/AM.Condo/Tasks/GetDockerMetadata.cs
@@ -37,6 +37,12 @@ namespace AM.Condo.Tasks
         public string Product { get; set; }
 
         /// <summary>
+        /// Gets or sets the root path of the repository.
+        /// </summary>
+        [Required]
+        public string RepositoryRoot { get; set; }
+
+        /// <summary>
         /// Gets or sets the build quality associated with the tag.
         /// </summary>
         [Required]
@@ -86,10 +92,26 @@ namespace AM.Condo.Tasks
             var parent = Path.GetDirectoryName(directory);
             var group = Path.GetFileName(directory);
 
-            // get the product name
-            var dockerName = !GetProjectMetadata.WellKnownFolders.Contains(group, StringComparer.OrdinalIgnoreCase)
-                ? group
-                : this.Product;
+            // set the docker name to the product name by default
+            var dockerName = this.Product;
+
+            // determine if the project is rooted
+            var rooted = string.Equals
+            (
+                Path.GetFullPath(directory),
+                Path.GetFullPath(this.RepositoryRoot),
+                StringComparison.OrdinalIgnoreCase
+            );
+
+            // determine if we are not rooted and the group is a well-known path
+            if (!rooted && !GetProjectMetadata.WellKnownFolders.Contains(group, StringComparer.OrdinalIgnoreCase))
+            {
+                // set the project name to the group
+                dockerName = group;
+
+                // use the parent of the group folder, which means multiple projects are contained within the folder
+                group = Path.GetFileName(parent);
+            }
 
             // get the docker file path
             var projectFile = Directory.GetFiles(directory, "*.*proj").FirstOrDefault();

--- a/src/AM.Condo/Tasks/GetProjectMetadata.cs
+++ b/src/AM.Condo/Tasks/GetProjectMetadata.cs
@@ -47,6 +47,12 @@ namespace AM.Condo.Tasks
         public string Product { get; set; }
 
         /// <summary>
+        /// Gets or sets the root of the repository.
+        /// </summary>
+        [Required]
+        public string RepositoryRoot { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether restore is enabled.
         /// </summary>
         public bool Restore { get; set; }
@@ -118,8 +124,16 @@ namespace AM.Condo.Tasks
             // get the product name
             var projectName = this.Product;
 
-            // determine if the group is a well-known folder path
-            if (!WellKnownFolders.Contains(group, StringComparer.OrdinalIgnoreCase))
+            // determine if the project is rooted
+            var rooted = string.Equals
+            (
+                Path.GetFullPath(directory),
+                Path.GetFullPath(this.RepositoryRoot),
+                StringComparison.OrdinalIgnoreCase
+            );
+
+            // determine if we are not rooted and the group is a well-known path
+            if (!rooted && !WellKnownFolders.Contains(group, StringComparer.OrdinalIgnoreCase))
             {
                 // set the project name to the group
                 projectName = group;

--- a/src/AM.Condo/Tasks/GetProjectMetadata.cs
+++ b/src/AM.Condo/Tasks/GetProjectMetadata.cs
@@ -127,8 +127,8 @@ namespace AM.Condo.Tasks
             // determine if the project is rooted
             var rooted = string.Equals
             (
-                Path.GetFullPath(directory),
-                Path.GetFullPath(this.RepositoryRoot),
+                Path.GetFullPath(directory + Path.DirectorySeparatorChar),
+                Path.GetFullPath(this.RepositoryRoot + Path.DirectorySeparatorChar),
                 StringComparison.OrdinalIgnoreCase
             );
 

--- a/src/AM.Condo/Tasks/GetProjectMetadata.cs
+++ b/src/AM.Condo/Tasks/GetProjectMetadata.cs
@@ -24,7 +24,10 @@ namespace AM.Condo.Tasks
     public class GetProjectMetadata : Task
     {
         #region Private Fields
-        private static readonly string[] WellKnownFolders = { "src", "test", "docs", "samples" };
+        /// <summary>
+        /// The list of well-known folders used for project layouts.
+        /// </summary>
+        public static readonly string[] WellKnownFolders = { "src", "test", "docs", "samples" };
 
         private readonly List<ITaskItem> projects = new List<ITaskItem>();
         #endregion
@@ -36,6 +39,12 @@ namespace AM.Condo.Tasks
         [Required]
         [Output]
         public ITaskItem[] Projects { get; set; }
+
+        /// <summary>
+        /// Gets or sets the product name to use when only a single project is present.
+        /// </summary>
+        [Required]
+        public string Product { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether restore is enabled.
@@ -106,21 +115,31 @@ namespace AM.Condo.Tasks
             var parent = Path.GetDirectoryName(directory);
             var group = Path.GetFileName(directory);
 
-            // determine if this is an msbuild project
-            var msbuild = path.EndsWith("proj");
-
-            // get the project name
-            var projectName = msbuild ? Path.GetFileNameWithoutExtension(path) : group;
+            // get the product name
+            var projectName = this.Product;
 
             // determine if the group is a well-known folder path
             if (!WellKnownFolders.Contains(group, StringComparer.OrdinalIgnoreCase))
             {
+                // set the project name to the group
+                projectName = group;
+
                 // use the parent of the group folder, which means multiple projects are contained within the folder
                 group = Path.GetFileName(parent);
             }
 
+            // determine if this is an msbuild project
+            var msbuild = path.EndsWith("proj");
+
+            // if the project is an msbuild project
+            if (msbuild)
+            {
+                // set the project name to the project name
+                projectName = Path.GetFileNameWithoutExtension(path);
+            }
+
             // set the group to lower
-            group = group.ToLower();
+            projectName = projectName.ToLower();
 
             // set the project directory path
             project.SetMetadata("ProjectDir", directory + Path.DirectorySeparatorChar);

--- a/test/AM.Condo.E2E.Test/AM.Condo.E2E.Test.csproj
+++ b/test/AM.Condo.E2E.Test/AM.Condo.E2E.Test.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[15.3.0, 16.0.0)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="[2.3.0, 3.0.0)" />
-    <PackageReference Include="xunit" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[2.3.1, 3.0.0)" />
+    <PackageReference Include="xunit" Version="[2.3.1, 3.0.0)" />
     <PackageReference Include="Moq" Version="[4.7.142, 5.0.0)" />
   </ItemGroup>
   <ItemGroup>

--- a/test/AM.Condo.LegacyNet.Test/AM.Condo.LegacyNet.Test.csproj
+++ b/test/AM.Condo.LegacyNet.Test/AM.Condo.LegacyNet.Test.csproj
@@ -1,21 +1,22 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <DebugType>portable</DebugType>
+    <TargetFramework>net462</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
+
   <ItemGroup>
-    <ProjectReference Include="../../src/AM.Condo.IO/AM.Condo.IO.csproj" />
     <ProjectReference Include="../../src/AM.Condo.Xunit/AM.Condo.Xunit.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[15.3.0, 16.0.0)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="[2.3.1, 3.0.0)" />
     <PackageReference Include="xunit" Version="[2.3.1, 3.0.0)" />
     <PackageReference Include="Moq" Version="[4.7.142, 5.0.0)" />
   </ItemGroup>
+
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/test/AM.Condo.LegacyNet.Test/LegacyTest.cs
+++ b/test/AM.Condo.LegacyNet.Test/LegacyTest.cs
@@ -1,0 +1,23 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="LegacyTest.cs" company="automotiveMastermind">
+//   © automotiveMastermind. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace AM.Condo.LegacyNet
+{
+    using Xunit;
+
+    [Purpose(PurposeType.Unit)]
+    [Priority(1)]
+    public class LegacyTest
+    {
+        [Fact]
+        public void TestExecutes()
+        {
+            var value = "test";
+
+            Assert.NotNull(value);
+        }
+    }
+}

--- a/test/AM.Condo.LegacyNetCore.Test/AM.Condo.LegacyNetCore.Test.csproj
+++ b/test/AM.Condo.LegacyNetCore.Test/AM.Condo.LegacyNetCore.Test.csproj
@@ -12,8 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[15.3.0, 16.0.0)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="[2.3.0, 3.0.0)" />
-    <PackageReference Include="xunit" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[2.3.1, 3.0.0)" />
+    <PackageReference Include="xunit" Version="[2.3.1, 3.0.0)" />
     <PackageReference Include="Moq" Version="[4.7.142, 5.0.0)" />
   </ItemGroup>
   <ItemGroup>

--- a/test/AM.Condo.MultipleTargets.Test/AM.Condo.MultipleTargets.Test.csproj
+++ b/test/AM.Condo.MultipleTargets.Test/AM.Condo.MultipleTargets.Test.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[15.3.0, 16.0.0)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="[2.3.0, 3.0.0)" />
-    <PackageReference Include="xunit" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[2.3.1, 3.0.0)" />
+    <PackageReference Include="xunit" Version="[2.3.1, 3.0.0)" />
     <PackageReference Include="Moq" Version="[4.7.142, 5.0.0)" />
   </ItemGroup>
   <ItemGroup>

--- a/test/AM.Condo.Test/AM.Condo.Test.csproj
+++ b/test/AM.Condo.Test/AM.Condo.Test.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[15.3.0, 16.0.0)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="[2.3.0, 3.0.0)" />
-    <PackageReference Include="xunit" Version="[2.3.0, 3.0.0)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[2.3.1, 3.0.0)" />
+    <PackageReference Include="xunit" Version="[2.3.1, 3.0.0)" />
     <PackageReference Include="Moq" Version="[4.7.142, 5.0.0)" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
* add support for building .NET Framework 4.6 and 4.7 applications (Windows only)
* do not create extended docker tags by default, which can be enabled using the following:
  - DOCKER_ENABLE_EXTENDED_TAGS = true (environment variable)
  - DockerEnableExtendedTags = true (build property)
* use product name for root-level projects
* allow root user for bower commands

Closes: #132 