### PR TITLE
feat(msbuild): add task to clone repositories

### DIFF
--- a/condo.build
+++ b/condo.build
@@ -18,7 +18,9 @@
     <PublishGitHubPages
       Source="$(DocsArtifactsRoot)condo"
       RepositoryUri="$(RepositoryUri)"
-      RepositoryRoot="$(RepositoryRoot)" />
+      RepositoryRoot="$(RepositoryRoot)"
+      AuthorName="$(AuthorName)"
+      AuthorEmail="$(AuthorEmail)" />
   </Target>
 
   <Import Project="$(CondoTargetsPath)Lifecycle.targets" />

--- a/src/AM.Condo.IO/Extensions/GitRepositoryFactoryExtensions.cs
+++ b/src/AM.Condo.IO/Extensions/GitRepositoryFactoryExtensions.cs
@@ -166,16 +166,16 @@ namespace AM.Condo.IO
         /// <param name="factory">
         /// The current factory instance.
         /// </param>
-        /// <param name="uri">
-        /// The URI of the git repository that should be cloned.
-        /// </param>
         /// <param name="path">
         /// The path in which the cloned repository should be created.
+        /// </param>
+        /// <param name="uri">
+        /// The URI of the git repository that should be cloned.
         /// </param>
         /// <returns>
         /// A new git repository instance that is tracking a cloned repository.
         /// </returns>
-        public static IGitRepositoryInitialized Clone(this IGitRepositoryFactory factory, string uri, string path)
+        public static IGitRepositoryInitialized Clone(this IGitRepositoryFactory factory, string path, string uri)
         {
             // clone the git repository
             return factory.Clone(path, uri, NoOpLogger);
@@ -188,11 +188,11 @@ namespace AM.Condo.IO
         /// <param name="factory">
         /// The current factory instance.
         /// </param>
-        /// <param name="uri">
-        /// The URI of the git repository that should be cloned.
-        /// </param>
         /// <param name="path">
         /// The path in which the cloned repository should be created.
+        /// </param>
+        /// <param name="uri">
+        /// The URI of the git repository that should be cloned.
         /// </param>
         /// <param name="logger">
         /// The logger used by the repository.
@@ -201,7 +201,7 @@ namespace AM.Condo.IO
         /// A new git repository instance that is tracking a cloned repository.
         /// </returns>
         public static IGitRepositoryInitialized Clone
-            (this IGitRepositoryFactory factory, string uri, string path, ILogger logger)
+            (this IGitRepositoryFactory factory, string path, string uri, ILogger logger)
         {
             // clone the git repository
             return factory.Clone(new PathManager(path), uri, logger);

--- a/src/AM.Condo/AM.Condo.tasks
+++ b/src/AM.Condo/AM.Condo.tasks
@@ -2,6 +2,7 @@
   <!-- include the individual tasks provided by condo -->
   <UsingTask AssemblyFile="condo.dll" TaskName="AM.Condo.Tasks.CheckoutBranch" />
   <UsingTask AssemblyFile="condo.dll" TaskName="AM.Condo.Tasks.CleanRepository" />
+  <UsingTask AssemblyFile="condo.dll" TaskName="AM.Condo.Tasks.CloneRepository" />
   <UsingTask AssemblyFile="condo.dll" TaskName="AM.Condo.Tasks.CreateRelease" />
   <UsingTask AssemblyFile="condo.dll" TaskName="AM.Condo.Tasks.DecodeBase64" />
   <UsingTask AssemblyFile="condo.dll" TaskName="AM.Condo.Tasks.FindCommand" />

--- a/src/AM.Condo/Targets/Initialize.targets
+++ b/src/AM.Condo/Targets/Initialize.targets
@@ -10,6 +10,15 @@
     <!-- define the default project name -->
     <ProjectName Condition=" '$(ProjectName)' == '' ">$(MSBuildProjectName)</ProjectName>
 
+    <!-- set defaults for git related activities -->
+    <AuthorName Condition=" '$(AuthorName)' == '' ">$(GIT_AUTHOR_NAME)</AuthorName>
+    <AuthorName Condition=" '$(AuthorName)' == '' ">$(Company)</AuthorName>
+    <AuthorName Condition=" '$(AuthorName)' == '' ">$(Authors)</AuthorName>
+    <AuthorName Condition=" '$(AuthorName)' == '' ">condo</AuthorName>
+
+    <AuthorEmail Condition=" '$(AuthorEmail)' == '' ">$(GIT_AUTHOR_EMAIL)</AuthorEmail>
+    <AuthorEmail Condition=" '$(AuthorEmail)' == '' ">open@automotivemastermind.com</AuthorEmail>
+
     <!-- get the solution and package root paths -->
     <RepositoryRoot     Condition=" '$(RepositoryRoot)'     == '' ">$(MSBuildStartupDirectory)</RepositoryRoot>
     <RepositoryRoot     Condition=" !HasTrailingSlash('$(RepositoryRoot)') ">$(RepositoryRoot)$(slash)</RepositoryRoot>

--- a/src/AM.Condo/Targets/Version/Conventional.targets
+++ b/src/AM.Condo/Targets/Version/Conventional.targets
@@ -71,13 +71,6 @@
   <!-- create a release commit -->
   <Target Name="CreateRelease" Condition=" $(CreateRelease) AND !$(IsPullRequest) AND $(CI) ">
     <PropertyGroup>
-      <AuthorName Condition=" '$(AuthorName)' == '' ">$(GIT_AUTHOR_NAME)</AuthorName>
-      <AuthorName Condition=" '$(AuthorName)' == '' ">$(Company)</AuthorName>
-      <AuthorName Condition=" '$(AuthorName)' == '' ">$(Authors)</AuthorName>
-      <AuthorName Condition=" '$(AuthorName)' == '' ">condo</AuthorName>
-
-      <AuthorEmail Condition=" '$(AuthorEmail)' == '' ">$(GIT_AUTHOR_EMAIL)</AuthorEmail>
-      <AuthorEmail Condition=" '$(AuthorEmail)' == '' ">open@automotivemastermind.com</AuthorEmail>
       <CurrentReleaseTag>$(VersionTagPrefix)$(NextRelease)</CurrentReleaseTag>
     </PropertyGroup>
 

--- a/src/AM.Condo/Tasks/CloneRepository.cs
+++ b/src/AM.Condo/Tasks/CloneRepository.cs
@@ -1,0 +1,102 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CloneRepository.cs" company="automotiveMastermind and contributors">
+// © automotiveMastermind and contributors. Licensed under MIT. See LICENSE and CREDITS for details.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace AM.Condo.Tasks
+{
+    using System;
+    using System.IO;
+
+    using AM.Condo.Diagnostics;
+    using AM.Condo.IO;
+
+    using Microsoft.Build.Framework;
+    using Microsoft.Build.Utilities;
+
+    /// <summary>
+    /// Represents a Microsoft Build task that is used to clone a repository.
+    /// </summary>
+    public class CloneRepository : Task
+    {
+        #region Properties and Indexers
+        /// <summary>
+        /// Gets or sets the root of the repository.
+        /// </summary>
+        [Required]
+        public string CloneRoot { get; set; }
+
+        /// <summary>
+        /// Gets or sets the remote URI of the repository for tracking the newly checked out branch.
+        /// </summary>
+        [Required]
+        public string RemoteUri { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the repository after it is cloned.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the branch, tag, or commit that should be checked out.
+        /// </summary>
+        public string Checkout { get; set; }
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Executes the <see cref="CloneRepository"/> task.
+        /// </summary>
+        /// <returns>
+        /// A value indicating whether or not the task executed successfully.
+        /// </returns>
+        public override bool Execute()
+        {
+            // create a new git repository factory
+            var factory = new GitRepositoryFactory();
+
+            try
+            {
+                // determine if the name is specified
+                if (!string.IsNullOrEmpty(this.Name))
+                {
+                    // include the name in the path
+                    this.CloneRoot = Path.Combine(this.CloneRoot, this.Name);
+                }
+
+                // determine if the directory exists
+                if (!Directory.Exists(this.CloneRoot))
+                {
+                    // create the directory
+                    Directory.CreateDirectory(this.CloneRoot);
+                }
+
+                // clone the repository
+                var repository = factory.Clone(this.CloneRoot, this.RemoteUri);
+
+                // determine if the checkout is set
+                if (!string.IsNullOrEmpty(this.Checkout))
+                {
+                    // checkout the appropriate ref
+                    repository.Checkout(this.Checkout);
+                }
+
+                // log a message
+                this.Log.LogMessage(MessageImportance.High, $"Cloned repository: {this.RemoteUri} to {this.CloneRoot}.");
+            }
+            catch (Exception netEx)
+            {
+                // log a warning
+                this.Log.LogWarningFromException(netEx);
+
+                // move on immediately
+                return false;
+            }
+
+            // we were successful
+            return true;
+        }
+        #endregion
+    }
+}

--- a/src/AM.Condo/Tasks/PublishGitHubPages.cs
+++ b/src/AM.Condo/Tasks/PublishGitHubPages.cs
@@ -39,6 +39,16 @@ namespace AM.Condo.Tasks
         public string RepositoryRoot { get; set; }
 
         /// <summary>
+        /// Gets or sets the author name used for git commits.
+        /// </summary>
+        public string AuthorName { get; set; } = "condo";
+
+        /// <summary>
+        /// Gets or sets the author email used for git commits.
+        /// </summary>
+        public string AuthorEmail { get; set; } = "open@automotivemastermind.com";
+
+        /// <summary>
         /// Gets or sets the branch to which to publish GitHub Pages.
         /// </summary>
         public string Branch { get; set; } = "gh-pages";
@@ -83,6 +93,10 @@ namespace AM.Condo.Tasks
             // clone the repository to a temporary path
             using (var repository = factory.Clone(this.RepositoryUri, logger))
             {
+                // set the username and email
+                repository.Username = this.AuthorName;
+                repository.Email = this.AuthorEmail;
+
                 // determine if an authorization header is available
                 if (!string.IsNullOrEmpty(authorization))
                 {


### PR DESCRIPTION
* add support for cloning a git repository as an msbuild task
* set git user and email in initialization to support publishing to GitHub Pages without creating a release
* set git user and email in the ```PublishGitHubPages``` task
* fix an issue with parameter order in the ```GitRepositoryFactoryExtensions.Clone``` extension methods

Closes: #140 