### PR TITLE
fix(version): include changelog in gitignore

### DIFF
--- a/src/AM.Condo/Targets/Version/.gitignore
+++ b/src/AM.Condo/Targets/Version/.gitignore
@@ -1,0 +1,1 @@
+!changelog.md

--- a/src/AM.Condo/Targets/Version/changelog.md
+++ b/src/AM.Condo/Targets/Version/changelog.md
@@ -1,0 +1,3 @@
+# CHANGE LOG
+
+> All notable changes to this project will be documented in this file.


### PR DESCRIPTION
The gitignore at the root was recently updated to exclude changelog.md, which accidentally excluded changelog.md in the version folder. This file represents the default header for the changelog file.