### PR TITLE
fix(release): do not push assets before tagging

### DIFF
--- a/src/AM.Condo.ChangeLog/ChangeLogWriter.cs
+++ b/src/AM.Condo.ChangeLog/ChangeLogWriter.cs
@@ -278,9 +278,6 @@ namespace AM.Condo.ChangeLog
                     { "header", currentCommit.Header }
                 };
 
-                // do not include the commit by default
-                var include = false;
-
                 // iterate over all notes on the current commit
                 foreach (var currentNote in currentCommit.Notes)
                 {
@@ -301,9 +298,6 @@ namespace AM.Condo.ChangeLog
                         // move on immediately
                         continue;
                     }
-
-                    // force include the commit
-                    include = true;
 
                     // attempt to get the group
                     if (!tempNotes.TryGetValue(display, out IDictionary<string, object> group))
@@ -340,7 +334,7 @@ namespace AM.Condo.ChangeLog
                     if (key.Equals(this.options.GroupBy, StringComparison.OrdinalIgnoreCase))
                     {
                         // attempt to get the display name mapping
-                        if (!this.options.ChangeLogTypes.TryGetValue(value, out string display) && !include)
+                        if (!this.options.ChangeLogTypes.TryGetValue(value, out string display))
                         {
                             // discard the commit
                             continue;

--- a/src/AM.Condo/Targets/Publish/Docker.targets
+++ b/src/AM.Condo/Targets/Publish/Docker.targets
@@ -22,4 +22,3 @@
     </AfterPublish>
   </PropertyGroup>
 </Project>
-

--- a/src/AM.Condo/Targets/Publish/Dotnet.targets
+++ b/src/AM.Condo/Targets/Publish/Dotnet.targets
@@ -47,7 +47,11 @@
       $(PublishDependsOn);
       DotNetPublish;
       CopyDotNetPublish;
-      PushPackages;
     </PublishDependsOn>
+
+    <AfterPublish>
+      $(AfterPublish);
+      PushPackages;
+    </AfterPublish>
   </PropertyGroup>
 </Project>

--- a/src/AM.Condo/Targets/Version/Conventional.targets
+++ b/src/AM.Condo/Targets/Version/Conventional.targets
@@ -117,8 +117,8 @@
     </AfterVersion>
 
     <AfterPublish>
-      $(AfterPublish);
       CreateRelease;
+      $(AfterPublish);
     </AfterPublish>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
* ensure that changelog is generated before publishing assets
* ensure that tag is created and pushed to remote before publishing assets
* resolve an issue where a BREAKING CHANGE in a commit that would usually be excluded from the change log could cause an exception

In the past, packages would be pushed to nuget and images pushed to docker prior to creating the release commit and tag. In the event that the commit + tag would fail, condo's versioning would no longer be in line with the packages / images. To support retrying of builds, this is no longer the case.