### PR TITLE
fix: print dotnet projects condition

### DIFF
--- a/src/AM.Condo/Targets/Prepare/Dotnet.targets
+++ b/src/AM.Condo/Targets/Prepare/Dotnet.targets
@@ -72,7 +72,7 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="PrintDotNetProjects" Condition=" $(DotNetBuild) OR $(DotNetPack) OR $(DotNetTest) OR $(DotNetPublish) ">
+  <Target Name="PrintDotNetProjects" Condition=" $(DotNetRequired) ">
     <Message Importance="High" Text="Project: %(DotNetMetadata.Description)" />
   </Target>
 


### PR DESCRIPTION
* update condition for printing of dotnet projects to use new `DotNetRequired` boolean