### PR TITLE
fix(dotnet): save assembly info after prepare

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,9 @@ image: Visual Studio 2017
 environment:
   GH_TOKEN:
     secure: HXDr0rstXSt8dsyX7xzWLlzcKCNxQQGPGyEoWv9Cu5eZMwe4T8wJm2K2qaVgcsQr
-  CONDO_CREATE_RELEASE: true
+  SKIP_NPM: true
+  SKIP_POLYMER: true
+  SKIP_BOWER: true
 install:
 - ps: Install-Product node lts
 build_script:

--- a/src/AM.Condo/Targets/Version.targets
+++ b/src/AM.Condo/Targets/Version.targets
@@ -81,7 +81,7 @@
   </Target>
 
   <!-- save assembly info files -->
-  <Target Name="SaveAssemblyInfo" Condition=" '@(SourceProjects->Count())' != '0' ">
+  <Target Name="SaveAssemblyInfo" Condition=" $(DotNetBuild) ">
     <SaveAssemblyInfo
         AssemblyInfoPath="%(SourceProjects.CondoAssemblyInfo)"
         RecommendedRelease="$(RecommendedRelease)"

--- a/src/AM.Condo/Targets/Version/Conventional.targets
+++ b/src/AM.Condo/Targets/Version/Conventional.targets
@@ -20,7 +20,7 @@
   <Import Project="$(ConventionStrategyTargets)" />
 
   <!-- get information about the commits within the repository -->
-  <Target Name="GetCommitInfo" Condition="$(HasGit)">
+  <Target Name="GetCommitInfo" Condition=" $(HasGit) ">
     <GetCommitInfo
       RepositoryRoot="$(RepositoryRoot)"
       IncludeInvalidCommits="$(IncludeInvalidCommits)"
@@ -107,7 +107,6 @@
 
     <VersionDependsOn>
       GetAssemblyInfo;
-      SaveAssemblyInfo;
       $(VersionDependsOn);
     </VersionDependsOn>
 
@@ -115,6 +114,11 @@
       $(AfterVersion);
       CheckoutReleaseBranch;
     </AfterVersion>
+
+    <AfterPrepare>
+      $(AfterPrepare);
+      SaveAssemblyInfo;
+    </AfterPrepare>
 
     <AfterPublish>
       CreateRelease;


### PR DESCRIPTION
* make `SaveAssemblyInfo` target fire after the prepare target

NOTE:
A previous change to condo moved when and how the dotnet project metadata was captured in order to improve performance in scenarios where a dotnet build would not execute, such as a clean target. This inadvertently stopped condo from writing the generated assembly info since the paths were not yet discovered during the version target.