### PR TITLE
fix(tasks): properly generate random folder on all .net OS's

### DIFF
--- a/src/AM.Condo/Tasks/GetContent.cs
+++ b/src/AM.Condo/Tasks/GetContent.cs
@@ -85,7 +85,9 @@ namespace AM.Condo.Tasks
             }
 
             // get the location where the file should be downloaded
-            var location = this.Extract ? Path.Combine(Path.GetTempPath(), Path.GetTempFileName()) : this.Destination;
+            var location = this.Extract
+                ? Path.Combine(Path.GetTempPath(), new Random().Next().ToString())
+                : this.Destination;
 
             // determine if the directory does not exist
             if (!Directory.Exists(location))


### PR DESCRIPTION
The implementation of the Path.GetTempFileName() actually creates a temporary file behind the scenes on some platforms. This will resolve the issue of attempting to create a directory where a file now already exists.