### PR TITLE
fix: release vs publish semantics

### DIFF
--- a/src/AM.Condo/Targets/Initialize.targets
+++ b/src/AM.Condo/Targets/Initialize.targets
@@ -80,8 +80,10 @@
 
   <!-- determine if the repository is managed by git -->
   <PropertyGroup>
-    <IsPullRequest Condition=" '$(PullRequestId)' != '' ">true</IsPullRequest>
     <RepositoryProvider Condition=" '$(RepositoryProvider)' == '' AND Exists('$(RepositoryRoot)$(slash).git') ">git</RepositoryProvider>
+
+    <AllowPublish Condition=" $(CI) AND !$(IsPullRequest) ">true</AllowPublish>
+    <AllowPublish Condition=" '$(AllowPublish)' == '' ">false</AllowPublish>
   </PropertyGroup>
 
   <ItemGroup>
@@ -178,6 +180,7 @@
     <Message Importance="High" Text="Build URI          : $(BuildUri)" Condition=" '$(BuildUri)' != '' " />
     <Message Importance="High" Text="CI Build           : $(CI)" />
     <Message Importance="High" Text="PR Build           : $(IsPullRequest)" />
+    <Message Importance="High" Text="Publish Build      : $(AllowPublish)" />
     <Message Importance="High" Text="Package Feed URI   : $(PackageFeedUri)" Condition=" '$(PackageFeedUri)' != '' " />
     <Message Importance="High" Text="Package Symbol URI : $(PackageSymbolUri)" Condition=" '$(PackageSymbolUri)' != '' " />
     <Message Importance="High" Text="Package Feed Key   : $(PackageFeedApiKey)" Condition=" '$(PackageFeedApiKey)' != '' " />

--- a/src/AM.Condo/Targets/Prepare/Docker.targets
+++ b/src/AM.Condo/Targets/Prepare/Docker.targets
@@ -71,7 +71,7 @@
 
       <DockerPush Condition=" '$(SKIP_DOCKER_PUSH)' != '' ">false</DockerPush>
       <DockerPush Condition=" '$(DockerPush)' != '' AND '$(DockerPush.ToLower())' != 'true' ">false</DockerPush>
-      <DockerPush Condition=" !$(CreateRelease) OR '$(DockerOrganization)' == '' ">false</DockerPush>
+      <DockerPush Condition=" !$(AllowPublish) OR '$(DockerOrganization)' == '' ">false</DockerPush>
       <DockerPush Condition=" '$(DockerPush)' == '' ">$(DockerBuild)</DockerPush>
     </PropertyGroup>
 

--- a/src/AM.Condo/Targets/Prepare/Dotnet.targets
+++ b/src/AM.Condo/Targets/Prepare/Dotnet.targets
@@ -43,7 +43,7 @@
 
       <DotNetPush Condition=" '$(SKIP_DOTNET_PUSH)' != '' ">false</DotNetPush>
       <DotNetPush Condition=" '$(DotNetPush)' != '' AND '$(DotNetPush.ToLower())' != 'true' ">false</DotNetPush>
-      <DotNetPush Condition=" !$(CreateRelease) OR !$(DotNetPack) OR '$(PackageFeedUri)' == '' ">false</DotNetPush>
+      <DotNetPush Condition=" !$(AllowPublish) OR !$(DotNetPack) OR '$(PackageFeedUri)' == '' ">false</DotNetPush>
       <DotNetPush Condition=" '$(DotNetPush)' == '' ">$(DotNetRequired)</DotNetPush>
     </PropertyGroup>
 

--- a/src/AM.Condo/Targets/Version.targets
+++ b/src/AM.Condo/Targets/Version.targets
@@ -26,10 +26,10 @@
   <Import Project="$(VersionStrategyTargets)" Condition=" Exists('$(VersionStrategyTargets)') "/>
 
   <PropertyGroup>
-    <CreateRelease Condition=" '$(CreateRelease)' == '' ">$(CONDO_CREATE_RELEASE)</CreateRelease>
-    <CreateRelease Condition=" $(IsPullRequest) OR !$(CI) ">false</CreateRelease>
-
     <BuildQuality  Condition=" '$(BuildQuality)' == '' ">$(CONDO_BUILD_QUALITY)</BuildQuality>
+
+    <CreateRelease Condition=" '$(CreateRelease)' == '' ">$(CONDO_CREATE_RELEASE)</CreateRelease>
+    <CreateRelease Condition=" '$(BuildQuality)' != '' ">false</CreateRelease>
   </PropertyGroup>
 
   <!-- gets the build quality based on the current convention -->

--- a/src/AM.Condo/Targets/Version/Angular/presets.targets
+++ b/src/AM.Condo/Targets/Version/Angular/presets.targets
@@ -20,7 +20,7 @@
 
     <IncludeInvalidCommits  Condition=" '$(IncludeInvalidCommits)'  == '' ">false</IncludeInvalidCommits>
 
-    <ReleaseMessage         Condition=" '$(ReleaseMessage)'         == '' ">chore(release): </ReleaseMessage>
+    <ReleaseMessage         Condition=" '$(ReleaseMessage)'         == '' ">docs: release notes for</ReleaseMessage>
 
     <HeaderPartial          Condition=" '$(HeaderPartial)'          == '' ">$(MSBuildThisFileDirectory)header.hbs</HeaderPartial>
     <FooterPartial          Condition=" '$(FooterPartial)'          == '' ">$(MSBuildThisFileDirectory)footer.hbs</FooterPartial>

--- a/src/AM.Condo/Targets/Version/Conventional.targets
+++ b/src/AM.Condo/Targets/Version/Conventional.targets
@@ -69,7 +69,7 @@
   </Target>
 
   <!-- create a release commit -->
-  <Target Name="CreateRelease" Condition=" $(CreateRelease) ">
+  <Target Name="CreateRelease">
     <PropertyGroup>
       <CurrentReleaseTag>$(VersionTagPrefix)$(NextRelease)</CurrentReleaseTag>
     </PropertyGroup>
@@ -95,7 +95,8 @@
       ReleaseMessage="$(ReleaseMessage)"
       AuthorName="$(AuthorName)"
       AuthorEmail="$(AuthorEmail)"
-      Push="$(AllowPushCommits)" />
+      Push="$(AllowPushCommits)"
+      Tag="$(CreateRelease)" />
   </Target>
 
   <PropertyGroup>

--- a/src/AM.Condo/Tasks/CreateRelease.cs
+++ b/src/AM.Condo/Tasks/CreateRelease.cs
@@ -36,7 +36,7 @@ namespace AM.Condo.Tasks
         /// Gets or sets the release message.
         /// </summary>
         [Required]
-        public string ReleaseMessage { get; set; } = "chore(release):";
+        public string ReleaseMessage { get; set; } = "docs: release notes for";
 
         /// <summary>
         /// Gets or sets the author name used for git commits.
@@ -52,6 +52,11 @@ namespace AM.Condo.Tasks
         /// Gets or sets a value indicating whether or not to push the release to the remote.
         /// </summary>
         public bool Push { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not to tag the release on the remote.
+        /// </summary>
+        public bool Tag { get; set; } = false;
         #endregion
 
         #region Methods
@@ -89,10 +94,17 @@ namespace AM.Condo.Tasks
                 var message = $"{this.ReleaseMessage} {this.Version} ***NO_CI***";
 
                 // create the commit and tag the release
-                repository.Commit(message).Tag(this.Version, this.Version);
+                repository.Commit(message);
 
-                // log a message
-                this.Log.LogMessage(MessageImportance.High, $"Created and tagged the release for version: {this.Version}...");
+                // determine if we should tag
+                if (this.Tag)
+                {
+                    // tag the release
+                    repository.Tag(this.Version, this.Version);
+
+                    // log a message
+                    this.Log.LogMessage(MessageImportance.High, $"Created and tagged the release for version: {this.Version}...");
+                }
 
                 // determine if we should push
                 if (this.Push)

--- a/src/AM.Condo/Tasks/PublishGitHubPages.cs
+++ b/src/AM.Condo/Tasks/PublishGitHubPages.cs
@@ -56,7 +56,7 @@ namespace AM.Condo.Tasks
         /// <summary>
         /// Gets or sets the commit message used to commit the documentation.
         /// </summary>
-        public string CommitMessage { get; set; } = "chore(docs): updating github pages";
+        public string CommitMessage { get; set; } = "docs: updating github pages";
         #endregion
 
         #region Methods

--- a/test/AM.Condo.E2E.Test/IO/GitLogTest.cs
+++ b/test/AM.Condo.E2E.Test/IO/GitLogTest.cs
@@ -120,7 +120,6 @@ namespace AM.Condo.IO
             "refactor",
             "perf",
             "test",
-            "chore",
             "revert",
             string.Empty,
             string.Empty,

--- a/test/AM.Condo.Test/Tasks/GetCommitInfoTest.cs
+++ b/test/AM.Condo.Test/Tasks/GetCommitInfoTest.cs
@@ -125,10 +125,10 @@ namespace AM.Condo.Tasks
                     {
                         new
                         {
-                            Raw = $"chore(kansas): somewhere over the rainbow{Environment.NewLine}where skies are blue.{Environment.NewLine}{Environment.NewLine}BREAKING CHANGE: something bad happened{Environment.NewLine}{Environment.NewLine}Closes: #34, #22",
-                            Header = "chore(kansas): somewhere over the rainbow",
+                            Raw = $"docs(kansas): somewhere over the rainbow{Environment.NewLine}where skies are blue.{Environment.NewLine}{Environment.NewLine}BREAKING CHANGE: something bad happened{Environment.NewLine}{Environment.NewLine}Closes: #34, #22",
+                            Header = "docs(kansas): somewhere over the rainbow",
                             Body = "where skies are blue.",
-                            Type = "chore",
+                            Type = "docs",
                             Scope = "kansas",
                             Subject = "somewhere over the rainbow",
                             Footer = $"BREAKING CHANGE: something bad happened{Environment.NewLine}{Environment.NewLine}Closes: #34, #22",


### PR DESCRIPTION
* changelog is always updated
* release is tagged based on `CreateRelease`
* things are published based on `AllowPublish` which is `true` when:
  * not a pull request
  * built on CI/CD
* stop using `chore`, which is now defunct