### PR TITLE
fix: continue to include 2.1.105 sdk for now

### DIFF
--- a/src/AM.Condo/Scripts/condo.ps1
+++ b/src/AM.Condo/Scripts/condo.ps1
@@ -153,7 +153,7 @@ function Install-DotNet() {
     }
 
     if (!$dotnetVersions) {
-        $dotnetVersions = @("1.1.8","2.1.300")
+        $dotnetVersions = @("1.1.8","2.1.105","2.1.300")
     }
 
     if ($env:SKIP_DOTNET_INSTALL) {

--- a/src/AM.Condo/Scripts/condo.sh
+++ b/src/AM.Condo/Scripts/condo.sh
@@ -242,7 +242,7 @@ fi
 
 # determine if the dotnet install channel is not already set
 if [ ${#DOTNET_VERSIONS[@]} -eq 0 ]; then
-    DOTNET_VERSIONS=('1.1.8' '2.1.300')
+    DOTNET_VERSIONS=('1.1.8' '2.1.105' '2.1.300')
 fi
 
 [ ! -d "$BUILD_ROOT" ] && mkdir -p $BUILD_ROOT


### PR DESCRIPTION
Include the 2.1.105 SDK for those relying on it from global.json