### PR TITLE
fix: get logs in topographical order

### DIFF
--- a/src/AM.Condo.IO/GitRepository.cs
+++ b/src/AM.Condo.IO/GitRepository.cs
@@ -359,7 +359,7 @@ namespace AM.Condo.IO
                 range += to;
             }
 
-            var cmd = $@"log {range} --format=""{Format}""";
+            var cmd = $@"log {range} --format=""{Format}"" --topo-order";
 
             // create the command used to get the history of commits
             var exec = this.Execute(cmd);


### PR DESCRIPTION
* ensure that `git log` used for semver always retrieves logs in topographical order

Resolves: #230 