### PR TITLE
fix(docker): allow gc job to run hourly

### DIFF
--- a/src/AM.Condo/Dockerfile.dotnet-1-docker-vsts-agent
+++ b/src/AM.Condo/Dockerfile.dotnet-1-docker-vsts-agent
@@ -81,8 +81,8 @@ ENV dotnet=/usr/bin/dotnet \
     docker=/usr/local/bin/docker \
     docker_compose=/usr/local/bin/docker-compose
 
-COPY $CONDO_SOURCE/docker-gc.sh /etc/cron.hourly
-RUN chmod u=rwx,g=rw,o=rw /etc/cron.hourly/docker-gc.sh
+COPY $CONDO_SOURCE/docker-gc.sh /etc/cron.hourly/docker-gc
+RUN chmod u=rwx,g=rw,o=rw /etc/cron.hourly/docker-gc
 
 ENTRYPOINT [ "/root/.am/condo/docker.sh" ]
 CMD [ "agent" ]

--- a/src/AM.Condo/Dockerfile.dotnet-1-docker.latest
+++ b/src/AM.Condo/Dockerfile.dotnet-1-docker.latest
@@ -102,8 +102,8 @@ ENV dotnet=/usr/bin/dotnet \
     docker=/usr/local/bin/docker \
     docker_compose=/usr/local/bin/docker-compose
 
-COPY $CONDO_SOURCE/docker-gc.sh /etc/cron.hourly
-RUN chmod u=rwx,g=rw,o=rw /etc/cron.hourly/docker-gc.sh
+COPY $CONDO_SOURCE/docker-gc.sh /etc/cron.hourly/docker-gc
+RUN chmod u=rwx,g=rw,o=rw /etc/cron.hourly/docker-gc
 
 ENTRYPOINT [ "/root/.am/condo/docker.sh" ]
 CMD [ "condo", "--", "/t:ci" ]

--- a/src/AM.Condo/Dockerfile.dotnet-1-vsts-agent
+++ b/src/AM.Condo/Dockerfile.dotnet-1-vsts-agent
@@ -79,8 +79,8 @@ ENV dotnet=/usr/bin/dotnet \
     dotnet2=/usr/bin/dotnet \
     condo=/usr/bin/condo
 
-COPY $CONDO_SOURCE/docker-gc.sh /etc/cron.hourly
-RUN chmod u=rwx,g=rw,o=rw /etc/cron.hourly/docker-gc.sh
+COPY $CONDO_SOURCE/docker-gc.sh /etc/cron.hourly/docker-gc
+RUN chmod u=rwx,g=rw,o=rw /etc/cron.hourly/docker-gc
 
 ENTRYPOINT [ "/root/.am/condo/docker.sh" ]
 CMD [ "agent" ]

--- a/src/AM.Condo/Dockerfile.dotnet-2-docker
+++ b/src/AM.Condo/Dockerfile.dotnet-2-docker
@@ -91,8 +91,8 @@ ENV DOTNET_SDK_VERSION=2.1.500 \
     docker=/usr/local/bin/docker \
     docker_compose=/usr/local/bin/docker-compose
 
-COPY $CONDO_SOURCE/docker-gc.sh /etc/cron.hourly
-RUN chmod u=rwx,g=rw,o=rw /etc/cron.hourly/docker-gc.sh
+COPY $CONDO_SOURCE/docker-gc.sh /etc/cron.hourly/docker-gc
+RUN chmod u=rwx,g=rw,o=rw /etc/cron.hourly/docker-gc
 
 ENTRYPOINT [ "/root/.am/condo/docker.sh" ]
 CMD [ "condo", "--", "/t:ci" ]

--- a/src/AM.Condo/Dockerfile.dotnet-2-docker-vsts-agent
+++ b/src/AM.Condo/Dockerfile.dotnet-2-docker-vsts-agent
@@ -72,8 +72,8 @@ ENV dotnet=/usr/bin/dotnet \
     docker=/usr/local/bin/docker \
     docker_compose=/usr/local/bin/docker-compose
 
-COPY $CONDO_SOURCE/docker-gc.sh /etc/cron.hourly
-RUN chmod u=rwx,g=rw,o=rw /etc/cron.hourly/docker-gc.sh
+COPY $CONDO_SOURCE/docker-gc.sh /etc/cron.hourly/docker-gc
+RUN chmod u=rwx,g=rw,o=rw /etc/cron.hourly/docker-gc
 
 ENTRYPOINT [ "/root/.am/condo/docker.sh" ]
 CMD [ "agent" ]

--- a/src/AM.Condo/Dockerfile.dotnet-2-vsts-agent
+++ b/src/AM.Condo/Dockerfile.dotnet-2-vsts-agent
@@ -70,8 +70,8 @@ ENV dotnet=/usr/bin/dotnet \
     dotnet2=/usr/bin/dotnet \
     condo=/usr/bin/condo
 
-COPY $CONDO_SOURCE/docker-gc.sh /etc/cron.hourly
-RUN chmod u=rwx,g=rw,o=rw /etc/cron.hourly/docker-gc.sh
+COPY $CONDO_SOURCE/docker-gc.sh /etc/cron.hourly/docker-gc
+RUN chmod u=rwx,g=rw,o=rw /etc/cron.hourly/docker-gc
 
 ENTRYPOINT [ "/root/.am/condo/docker.sh" ]
 CMD [ "agent" ]


### PR DESCRIPTION
running jobs from the /etc/cron.* folders are done via `run-parts`. this program has specific restrictions on filenames, no extensions are allowed. removed the extension from `docker-gc.sh -> docker-gc` solves the issue

fixes #248 