### PR TITLE
feat: add support for compression in get-release task

### DIFF
--- a/src/AM.Condo/Tasks/GetRelease.cs
+++ b/src/AM.Condo/Tasks/GetRelease.cs
@@ -133,19 +133,6 @@ namespace AM.Condo.Tasks
                     // deserialize the object
                     var value = JsonConvert.DeserializeObject<GitHubRelease>(json);
 
-                    // create the version tag
-                    var version = $".version-{value.Id}";
-
-                    // create the version path
-                    var versionPath = Path.Combine(this.Destination, version);
-
-                    // determine if the file exists
-                    if (File.Exists(versionPath))
-                    {
-                        // move on immediately
-                        return true;
-                    }
-
                     // find the asset
                     var asset = string.IsNullOrEmpty(this.Asset)
                         ? value.Assets.SingleOrDefault()
@@ -159,6 +146,19 @@ namespace AM.Condo.Tasks
 
                         // return false
                         return false;
+                    }
+
+                    // create the version tag
+                    var version = $".version-{value.Id}-{asset.Id}";
+
+                    // create the version path
+                    var versionPath = Path.Combine(this.Destination, version);
+
+                    // determine if the file exists
+                    if (File.Exists(versionPath))
+                    {
+                        // move on immediately
+                        return true;
                     }
 
                     // set the asset name
@@ -205,6 +205,15 @@ namespace AM.Condo.Tasks
             {
                 // extract the files
                 this.ExtractTarGzip(stream);
+
+                // move on immediately
+                return;
+            }
+
+            if (this.Asset.EndsWith(".gz", StringComparison.InvariantCultureIgnoreCase))
+            {
+                // extract the file
+                this.ExtractGzip(stream);
 
                 // move on immediately
                 return;

--- a/src/AM.Condo/condo.csproj
+++ b/src/AM.Condo/condo.csproj
@@ -18,6 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="SharpZipLib" Version="1.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
   </ItemGroup>

--- a/test/AM.Condo.Test/Tasks/GetReleaseTest.cs
+++ b/test/AM.Condo.Test/Tasks/GetReleaseTest.cs
@@ -1,0 +1,176 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="GetReleaseTest.cs" company="automotiveMastermind and contributors">
+//   © automotiveMastermind and contributors. Licensed under MIT. See LICENSE and CREDITS for details.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace AM.Condo.Tasks
+{
+    using System.IO;
+    using AM.Condo.IO;
+
+    using Microsoft.Build.Framework;
+    using Moq;
+    using Xunit;
+
+    [Class(nameof(GetBuildTime))]
+    [Purpose(PurposeType.Unit)]
+    public class GetReleaseTest
+    {
+        [Fact]
+        [Priority(2)]
+        public void Execute_WhenAssetIsGzipTarball_ThenExtracts()
+        {
+            using (var temp = new TemporaryPath())
+            {
+                // arrange
+                var organization = "automotivemastermind";
+                var repository = "condo-test";
+                var tag = "v1.0-test";
+
+                var destination = temp.FullPath;
+                var asset = "release-test.tar.gz";
+
+                var engine = new Mock<IBuildEngine>();
+                engine.Setup(mock => mock.LogWarningEvent(It.IsAny<BuildWarningEventArgs>())).Verifiable();
+
+                var actual = new GetRelease()
+                {
+                    BuildEngine = engine.Object,
+                    Organization = organization,
+                    Repository = repository,
+                    Tag = tag,
+                    Destination = destination,
+                    Asset = asset
+                };
+
+                var expected = temp.Combine("example/example.txt");
+
+                // act
+                actual.Execute();
+
+                // assert
+                engine.Verify(mock => mock.LogWarningEvent(It.IsAny<BuildWarningEventArgs>()), Times.Never);
+                engine.Verify(mock => mock.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()), Times.Never);
+                Assert.True(File.Exists(expected), $"File not found at {expected}");
+            }
+        }
+
+        [Fact]
+        [Priority(2)]
+        public void Execute_WhenAssetIsTarball_ThenExtracts()
+        {
+            using (var temp = new TemporaryPath())
+            {
+                // arrange
+                var organization = "automotivemastermind";
+                var repository = "condo-test";
+                var tag = "v1.0-test";
+
+                var destination = temp.FullPath;
+                var asset = "release-test.tar";
+
+                var engine = new Mock<IBuildEngine>();
+                engine.Setup(mock => mock.LogWarningEvent(It.IsAny<BuildWarningEventArgs>())).Verifiable();
+
+                var actual = new GetRelease()
+                {
+                    BuildEngine = engine.Object,
+                    Organization = organization,
+                    Repository = repository,
+                    Tag = tag,
+                    Destination = destination,
+                    Asset = asset
+                };
+
+                var expected = temp.Combine("example/example.txt");
+
+                // act
+                actual.Execute();
+
+                // assert
+                engine.Verify(mock => mock.LogWarningEvent(It.IsAny<BuildWarningEventArgs>()), Times.Never);
+                engine.Verify(mock => mock.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()), Times.Never);
+                Assert.True(File.Exists(expected), $"File not found at {expected}");
+            }
+        }
+
+        [Fact]
+        [Priority(2)]
+        public void Execute_WhenAssetIsZip_ThenExtracts()
+        {
+            using (var temp = new TemporaryPath())
+            {
+                // arrange
+                var organization = "automotivemastermind";
+                var repository = "condo-test";
+                var tag = "v1.0-test";
+
+                var destination = temp.FullPath;
+                var asset = "release-test.zip";
+
+                var engine = new Mock<IBuildEngine>();
+                engine.Setup(mock => mock.LogWarningEvent(It.IsAny<BuildWarningEventArgs>())).Verifiable();
+
+                var actual = new GetRelease()
+                {
+                    BuildEngine = engine.Object,
+                    Organization = organization,
+                    Repository = repository,
+                    Tag = tag,
+                    Destination = destination,
+                    Asset = asset
+                };
+
+                var expected = temp.Combine("example/example.txt");
+
+                // act
+                actual.Execute();
+
+                // assert
+                engine.Verify(mock => mock.LogWarningEvent(It.IsAny<BuildWarningEventArgs>()), Times.Never);
+                engine.Verify(mock => mock.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()), Times.Never);
+                Assert.True(File.Exists(expected), $"File not found at {expected}");
+            }
+        }
+
+        [Fact]
+        [Priority(2)]
+        public void Execute_WhenAssetIsGZip_ThenExtracts()
+        {
+            using (var temp = new TemporaryPath())
+            {
+                // arrange
+                var organization = "automotivemastermind";
+                var repository = "condo-test";
+                var tag = "v1.0-test";
+
+                var destination = temp.FullPath;
+                var asset = "release-test.gz";
+
+                var engine = new Mock<IBuildEngine>();
+                engine.Setup(mock => mock.LogWarningEvent(It.IsAny<BuildWarningEventArgs>())).Verifiable();
+
+                var actual = new GetRelease()
+                {
+                    BuildEngine = engine.Object,
+                    Organization = organization,
+                    Repository = repository,
+                    Tag = tag,
+                    Destination = destination,
+                    Asset = asset
+                };
+
+                var expected = temp.Combine("release-test");
+
+                // act
+                actual.Execute();
+
+                // assert
+                engine.Verify(mock => mock.LogWarningEvent(It.IsAny<BuildWarningEventArgs>()), Times.Never);
+                engine.Verify(mock => mock.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()), Times.Never);
+                Assert.True(File.Exists(expected), $"File not found at {expected}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Enable the `GetRelease` task to handle various compression types:

* enable tarball expansion (.tar)
* enable gzip decompression (.tar.gz and .gz)
* enable zip decompression (.zip)