### PR TITLE
docs(env): useful env variables for skipping build steps in dotnet and go

### DIFF
--- a/docs/condo/environment-variables.md
+++ b/docs/condo/environment-variables.md
@@ -1,12 +1,35 @@
-# Enviornment Variables
+# Environment Variables
 
-## Building condo
+## Condo
 
 Variable            | Type     | What does it do
 --------------------|----------|----------------
-SKIP_NPM            | `bool`     | Skips tests for npm install
-SKIP_BOWER          | `bool`     | Skips tests for bower install
-SKIP_POLYMER        | `bool`     | Skips tests for polymer
+SKIP_NPM            | `bool`   | Skips all npm build steps
+SKIP_BOWER          | `bool`   | Skips all bower build steps
+SKIP_POLYMER        | `bool`   | Skips all polymer build steps
+SKIP_DOTNET         | `bool`   | Skips all dotnet build steps
+SKIP_GO             | `bool`   | Skips all go build steps
+---
+
+## Dotnet
+
+Variable            | Type     | What does it do
+--------------------|----------|----------------
+SKIP_DOTNET_RESTORE | `bool`   | Skips restoring packages
+SKIP_DOTNET_BUILD   | `bool`   | Skips building
+SKIP_DOTNET_TEST    | `bool`   | Skips testing
+SKIP_DOTNET_PUBLISH | `bool`   | Skips publishing project
+SKIP_DOTNET_PUSH    | `bool`   | Skips pushing nuget packages
+---
+
+## Go
+
+Variable            | Type     | What does it do
+--------------------|----------|----------------
+SKIP_GO_INSTALL     | `bool`   | Skips restoring packages
+SKIP_GO_BUILD       | `bool`   | Skips building
+SKIP_GO_TEST        | `bool`   | Skips testing
+SKIP_GO_PUBLISH     | `bool`   | Skips publishing project
 ---
 
 ## Building docker containers


### PR DESCRIPTION
docs for skipping build steps for dotnet and go