### PR TITLE
fix(nuget): default to skipping nuget packages if they have already been pushed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,11 @@ indent_size = 4
 char_set = utf-8
 insert_final_newline = true
 
-[*.{js,json,targets,html,csproj,build,yml,yaml}]
+[*.{js,json,yml,yaml}]
+indent_size = 2
+
+[*.*{proj}]
+indent_size = 2
+
+[*.{props,targets}]
 indent_size = 2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,5 +40,7 @@
     "**/condo.cmd": true,
     "artifacts/**": true,
     "**/docs/api": true
-  }
+  },
+  "omnisharp.enableRoslynAnalyzers": true,
+  "omnisharp.enableEditorConfigSupport": true
 }

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,16 +1,16 @@
 <Project>
   <PropertyGroup>
-    <BuildVersion>16.0.461</BuildVersion>
-    <CoverletVersion>2.6.1</CoverletVersion>
-    <JetBrainsVersion>2019.1.1</JetBrainsVersion>
-    <MoqVersion>4.10.0</MoqVersion>
-    <NuGetVersion>5.1.0</NuGetVersion>
+    <BuildVersion>16.5.0</BuildVersion>
+    <CoverletVersion>2.8.1</CoverletVersion>
+    <JetBrainsVersion>2020.1.0</JetBrainsVersion>
+    <MoqVersion>4.14.1</MoqVersion>
+    <NuGetVersion>5.5.1</NuGetVersion>
     <SourceLinkVersion>2.8.3</SourceLinkVersion>
-    <StyleCopVersion>1.1.0-beta009</StyleCopVersion>
+    <StyleCopVersion>1.1.118</StyleCopVersion>
     <XUnitVersion>2.4.1</XUnitVersion>
   </PropertyGroup>
 
   <PropertyGroup>
-    <MSBuildTestSDKVersion>16.1.0</MSBuildTestSDKVersion>
+    <MSBuildTestSDKVersion>16.6.1</MSBuildTestSDKVersion>
   </PropertyGroup>
 </Project>

--- a/src/AM.Condo/Tasks/PushNuGetPackage.cs
+++ b/src/AM.Condo/Tasks/PushNuGetPackage.cs
@@ -246,7 +246,7 @@ namespace AM.Condo.Tasks
                         disableBuffering: false,
                         noSymbols: this.NoSymbols,
                         noServiceEndpoint: false,
-                        skipDuplicate: false,
+                        skipDuplicate: true,
                         logger: logger
                     );
 

--- a/src/AM.Condo/condo.csproj
+++ b/src/AM.Condo/condo.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpZipLib" Version="1.0.0" />
+    <PackageReference Include="SharpZipLib" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- default to skipping Nuget Packages that fail because they already exist on the server. This will make it possible to rerun pipelines.
- Upgrade build dependencies
- Turn on roslyn analyzers for vscode