### PR TITLE
feat(versioning): introduce new variable to append a suffix to the version

### DIFF
--- a/docs/condo/environment-variables.md
+++ b/docs/condo/environment-variables.md
@@ -11,6 +11,14 @@ SKIP_DOTNET         | `bool`   | Skips all dotnet build steps
 SKIP_GO             | `bool`   | Skips all go build steps
 ---
 
+## Versioning
+
+Variable            | Type     | What does it do
+--------------------|----------|----------------
+CONDO_BUILD_QUALITY | `string` | Override the build quality (alpha, beta)
+CONDO_SUFFIX_TAG    | `string` | Append a suffix to all versions
+CONDO_CREATE_RELEASE| `bool`   | Override for determining if this is a release build
+
 ## Dotnet
 
 Variable            | Type     | What does it do

--- a/src/AM.Condo/Targets/Version.targets
+++ b/src/AM.Condo/Targets/Version.targets
@@ -27,7 +27,7 @@
 
   <PropertyGroup>
     <BuildQuality  Condition=" '$(BuildQuality)' == '' ">$(CONDO_BUILD_QUALITY)</BuildQuality>
-
+    <SuffixTag     Condition=" '$(SuffixTag)' == '' ">$(CONDO_SUFFIX_TAG)</SuffixTag>
     <CreateRelease Condition=" '$(CreateRelease)' == '' ">$(CONDO_CREATE_RELEASE)</CreateRelease>
     <CreateRelease Condition=" '$(BuildQuality)' != '' ">false</CreateRelease>
   </PropertyGroup>
@@ -70,6 +70,7 @@
         BuildId="$(BuildId)"
         CommitId="$(CommitId)"
         BuildQuality="$(BuildQuality)"
+        SuffixTag="$(SuffixTag)"
         StartDateUtc="$(StartDateUtc)"
         BuildDateUtc="$(BuildDateUtc)">
       <Output TaskParameter="AssemblyVersion" PropertyName="AssemblyVersion" />
@@ -123,6 +124,7 @@
     <Message Importance="High" Text="File Version       : $(FileVersion)" />
     <Message Importance="High" Text="Build Quality      : $(BuildQuality)" />
     <Message Importance="High" Text="Pre-Release Tag    : $(PreReleaseTag)" />
+    <Message Importance="High" Text="Suffix Tag         : $(SuffixTag)" />
     <Message Importance="High" Text="Major Version      : $(MajorVersion)" />
     <Message Importance="High" Text="Create Release     : $(CreateRelease)" />
 

--- a/src/AM.Condo/Tasks/GetAssemblyInfo.cs
+++ b/src/AM.Condo/Tasks/GetAssemblyInfo.cs
@@ -123,8 +123,6 @@ namespace AM.Condo.Tasks
                 return false;
             }
 
-            // define a variable to retain the date
-
             // attempt to parse the date
             if (!DateTime.TryParse(this.BuildDateUtc, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out DateTime now))
             {
@@ -138,8 +136,6 @@ namespace AM.Condo.Tasks
 
             // ensure that the date is always universal time
             now = now.ToUniversalTime();
-
-            // define a variable to retain the start date
 
             // attempt to parse the start date
             if (!DateTime.TryParse(this.StartDateUtc, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out DateTime start))

--- a/src/AM.Condo/Tasks/GetAssemblyInfo.cs
+++ b/src/AM.Condo/Tasks/GetAssemblyInfo.cs
@@ -39,6 +39,11 @@ namespace AM.Condo.Tasks
         public string BuildQuality { get; set; }
 
         /// <summary>
+        /// Gets or sets the suffix tag.
+        /// </summary>
+        public string SuffixTag { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether or not the build is a CI build.
         /// </summary>
         public bool CI { get; set; } = false;
@@ -119,10 +124,9 @@ namespace AM.Condo.Tasks
             }
 
             // define a variable to retain the date
-            DateTime now;
 
             // attempt to parse the date
-            if (!DateTime.TryParse(this.BuildDateUtc, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out now))
+            if (!DateTime.TryParse(this.BuildDateUtc, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out DateTime now))
             {
                 // log an error
                 this.Log.LogError
@@ -136,10 +140,9 @@ namespace AM.Condo.Tasks
             now = now.ToUniversalTime();
 
             // define a variable to retain the start date
-            DateTime start;
 
             // attempt to parse the start date
-            if (!DateTime.TryParse(this.StartDateUtc, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out start))
+            if (!DateTime.TryParse(this.StartDateUtc, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out DateTime start))
             {
                 // log an error
                 this.Log.LogError
@@ -215,6 +218,13 @@ namespace AM.Condo.Tasks
 
                 // append the prerelease tag to the informational version
                 this.InformationalVersion += Invariant($"-{this.PreReleaseTag}");
+            }
+
+            // determine if the suffix tag is now set
+            if (!string.IsNullOrEmpty(this.SuffixTag))
+            {
+                // apppend the suffix tag to the informational version
+                this.InformationalVersion += Invariant($"-{this.SuffixTag}");
             }
 
             // set the major version

--- a/test/AM.Condo.Test/Tasks/GetAssemblyInfoTest.cs
+++ b/test/AM.Condo.Test/Tasks/GetAssemblyInfoTest.cs
@@ -361,7 +361,7 @@ namespace AM.Condo.Tasks
         [Fact]
         [Priority(1)]
         [Purpose(PurposeType.Unit)]
-        public void Execute_WhenProductionReleaseBranch_Succeeds()
+        public void Execute_WhenProductionReleaseBranch_WithSuffix_Succeeds()
         {
             // arrange
             var start = new DateTime(2015, 1, 1).ToString("o", CultureInfo.InvariantCulture);
@@ -371,13 +371,14 @@ namespace AM.Condo.Tasks
             var commitId = default(string);
             var branch = "master";
             var ci = true;
+            var suffixTag = "LTS";
 
             var expected = new
             {
                 SemanticVersion = "1.0.0",
                 AssemblyVersion = "1.0.0",
                 FileVersion = "1.0.01002.2359",
-                InformationalVersion = "1.0.0",
+                InformationalVersion = $"1.0.0-{suffixTag}",
                 PreReleaseTag = default(string),
                 BuildQuality = default(string),
                 BuildDateUtc = now,
@@ -392,6 +393,7 @@ namespace AM.Condo.Tasks
             {
                 RecommendedRelease = "1.0.0",
                 BuildQuality = expected.BuildQuality,
+                SuffixTag = suffixTag,
                 StartDateUtc = start,
                 BuildDateUtc = now,
                 BuildId = buildId,


### PR DESCRIPTION
Introduce new env var `CONDO_SUFFIX_TAG` to allow for appending a suffix to the end of a version. This also allows normal release operation on different branches, for instance an LTS branch does not have to be bound to a major version anymore, this can be convenient in rare cases. 

old version template:
`Major.Minor.Patch.BuildQuality.BuildId.CommitId`

new version template:
`Major.Minor.Patch.BuildQuality.BuildId.CommitId.SuffixTag`