### PR TITLE
fix(version): include main as default production branch

### DIFF
--- a/src/AM.Condo.Abstractions/IO/GitFlowOptions.cs
+++ b/src/AM.Condo.Abstractions/IO/GitFlowOptions.cs
@@ -20,7 +20,7 @@ namespace AM.Condo.IO
         /// <summary>
         /// Gets or sets the name of the branch used for production releases.
         /// </summary>
-        public string ProductionReleaseBranch { get; set; } = "master";
+        public string ProductionReleaseBranch { get; set; } = "main";
 
         /// <summary>
         /// Gets or sets the prefix of the branches used for feature development.

--- a/src/AM.Condo.IO/GitRepository.cs
+++ b/src/AM.Condo.IO/GitRepository.cs
@@ -432,7 +432,7 @@ namespace AM.Condo.IO
             }
 
             // set the gitflow options
-            this.Config("gitflow.branch.master", options.ProductionReleaseBranch);
+            this.Config("gitflow.branch.main", options.ProductionReleaseBranch);
             this.Config("gitflow.branch.develop", options.NextReleaseBranch);
             this.Config("gitflow.prefix.feature", $"{options.FeatureBranchPrefix}/");
             this.Config("gitflow.prefix.bugfix", $"{options.BugfixBranchPrefix}/");

--- a/src/AM.Condo/Tasks/GetBuildQuality.cs
+++ b/src/AM.Condo/Tasks/GetBuildQuality.cs
@@ -7,8 +7,8 @@
 namespace AM.Condo.Tasks
 {
     using System;
+    using System.Linq;
     using System.Security;
-
     using Microsoft.Build.Framework;
     using Microsoft.Build.Utilities;
 
@@ -61,7 +61,7 @@ namespace AM.Condo.Tasks
         /// <summary>
         /// Gets or sets the name used to identify the integration branch for production.
         /// </summary>
-        public string ProductionReleaseBranch { get; set; } = "master";
+        public string[] ProductionReleaseBranch { get; set; } = new string[] { "main", "master" };
 
         /// <summary>
         /// Gets or sets the default build quality, which is used whenever a branch specific build quality is not set
@@ -135,8 +135,8 @@ namespace AM.Condo.Tasks
                 return true;
             }
 
-            // determine if the branch is the master branch
-            if (this.Branch.Equals(this.ProductionReleaseBranch, StringComparison.OrdinalIgnoreCase))
+            // determine if the branch is the main or master branch
+            if (this.ProductionReleaseBranch.Any(b => this.Branch.Equals(b, StringComparison.OrdinalIgnoreCase)))
             {
                 // set the build quality to the master branch build quality
                 this.SetBuildQuality(this.ProductionReleaseBranchBuildQuality);

--- a/test/AM.Condo.Test/Tasks/GetBuildQualityTest.cs
+++ b/test/AM.Condo.Test/Tasks/GetBuildQualityTest.cs
@@ -1,0 +1,48 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="GetBuildQualityTest.cs" company="automotiveMastermind and contributors">
+//   © automotiveMastermind and contributors. Licensed under MIT. See LICENSE and CREDITS for details.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+using Xunit;
+
+namespace AM.Condo.Tasks
+{
+    [Class(nameof(GetAssemblyInfo))]
+    public class GetBuildQualityTest
+    {
+        [Theory]
+        [InlineData("master", null)]
+        [InlineData("main", null)]
+        [InlineData("some feature", "alpha")]
+        [Priority(2)]
+        [Purpose(PurposeType.Unit)]
+        public void Execute_WhenBranchName_ThenProperBuildQuality(string branchName, string expectedBuildQuality)
+        {
+            // arrange
+            var ci = true;
+
+            var expected = new
+            {
+                BuildQuality = expectedBuildQuality,
+                CI = ci,
+            };
+
+            var actual = new GetBuildQuality
+            {
+                BuildQuality = expected.BuildQuality,
+                CI = ci,
+                Branch = branchName
+            };
+
+            // act
+            var result = actual.Execute();
+
+            // assert
+            Assert.True(result);
+            Assert.Equal(expected.BuildQuality, actual.BuildQuality);
+        }
+    }
+}


### PR DESCRIPTION
New Git repositories do not have **master** branch, instead they have **main** branch.

Condo assigns "production" build quality only to builds from master branch. This results in builds from main branch, being _alpha_ builds.

This PR addresses this issue. Backward compatibility is maintained - master branch builds will remain as before.